### PR TITLE
Changed ingress to use Service port instead of Pod port

### DIFF
--- a/charts/aruba-uxi/CHANGELOG.md
+++ b/charts/aruba-uxi/CHANGELOG.md
@@ -18,6 +18,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - what has been fixed
 
+## [2.1.5] - 2021-10-21
+
+### Changed
+
+- Service uses port 80 by default and the ingress tries to talk to Service on Pod port. This is not allowing Service and Ingress to communicate.
+- To fix the above mentioned issue, the ingress will now use port 80 by default if `.service.port` is not defined.
+
 ## [2.1.4] - 2021-10-21
 
 ### Changed

--- a/charts/aruba-uxi/Chart.yaml
+++ b/charts/aruba-uxi/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: aruba-uxi
 description: A Helm chart for Aruba UXI kubernetes resources
 type: application
-version: 2.1.4
+version: 2.1.5
 maintainers:
   - name: Aruba-UXI

--- a/charts/aruba-uxi/templates/application-ingress.yaml
+++ b/charts/aruba-uxi/templates/application-ingress.yaml
@@ -1,6 +1,7 @@
 {{- range $name, $data := .Values.applications }}
 {{- $ingress := default dict $data.ingress }}
 {{- $svcPort := $data.port }}
+{{- $service := default dict $data.service }}
 {{- $additionalLabels := deepCopy (default dict $.Values.global.labels) | mustMerge (default dict $data.labels) }}
 {{- if $ingress.enabled -}}
 apiVersion: networking.k8s.io/v1beta1
@@ -33,10 +34,10 @@ spec:
         backend:
           {{- if $path.backend }}
           serviceName: {{ default $name $path.backend.serviceName }}
-          servicePort: {{ default $svcPort $path.backend.servicePort }}
+          servicePort: {{ default 80 $path.backend.servicePort }}
           {{- else }}
           serviceName: {{ $name }}
-          servicePort: {{ $svcPort }}
+          servicePort: {{ default 80 $service.port }}
           {{- end }}
       {{- end }}
   {{- end }}

--- a/examples/aruba-uxi-example/output-local.yaml
+++ b/examples/aruba-uxi-example/output-local.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -46,7 +46,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-2.1.4
+        helm.sh/chart: aruba-uxi-2.1.5
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -36,7 +36,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -60,7 +60,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -85,7 +85,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -103,7 +103,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-2.1.4
+        helm.sh/chart: aruba-uxi-2.1.5
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -219,7 +219,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -236,7 +236,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-worker
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-2.1.4
+        helm.sh/chart: aruba-uxi-2.1.5
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -283,7 +283,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-consumer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -331,7 +331,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -393,7 +393,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -410,7 +410,7 @@ spec:
         pathType: ImplementationSpecific
         backend:
           serviceName: example-service
-          servicePort: 8000
+          servicePort: 80
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/imagepullsecret.yaml
 apiVersion: bitnami.com/v1alpha1
@@ -419,7 +419,7 @@ metadata:
   name: sealed-image-pull-secret
   labels:
     app.kubernetes.io/name: sealed-image-pull-secret
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     namespace: default
 spec:
@@ -431,7 +431,7 @@ spec:
       name: sealed-image-pull-secret
       labels:
       app.kubernetes.io/name: sealed-image-pull-secret
-      helm.sh/chart: aruba-uxi-2.1.4
+      helm.sh/chart: aruba-uxi-2.1.5
       app.kubernetes.io/managed-by: Helm
       namespace: default
     type: kubernetes.io/dockerconfigjson
@@ -444,7 +444,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-access
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -461,7 +461,7 @@ metadata:
   labels:
     app.kubernetes.io/name: database-url
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -476,7 +476,7 @@ metadata:
   name: sentry-dsn
   labels:
     app.kubernetes.io/name: sentry-dsn
-    helm.sh/chart: aruba-uxi-2.1.4
+    helm.sh/chart: aruba-uxi-2.1.5
     app.kubernetes.io/managed-by: Helm
     namespace: default
 spec:


### PR DESCRIPTION
## Description

The Ingress template was using Pod port to communicate with the Service. Ingress is now set to use port 80 by default (i.e. Service default port) if `.service.port` is not defined.

## Types of changes

_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code removal (deleting unused / redundant code)
- [ ] Documentation update (if none of the other choices apply)

## Further Information

JIRA Ticket: https://uxi.atlassian.net/browse/UXI-826
