### PR TITLE
fix: Interchanging application and cronjob sentry-dsn file names

### DIFF
--- a/charts/aruba-uxi/CHANGELOG.md
+++ b/charts/aruba-uxi/CHANGELOG.md
@@ -18,6 +18,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - what has been fixed
 
+## [2.3.1] - 2021-11-05
+
+### Changed
+
+The `application-sentry-dsn.yaml` and `cronjob-sentry-dsn.yaml` files needed to be renamed(interchanged) because the `application-sentry-dsn.yaml` has logic to add sentry-dsn for a cronjob and vice versa for `cronjob-sentry-dsn.yaml`.
+
 ## [2.3.0] - 2021-11-05
 
 ### Changed

--- a/charts/aruba-uxi/CHANGELOG.md
+++ b/charts/aruba-uxi/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
-The `application-sentry-dsn.yaml` and `cronjob-sentry-dsn.yaml` files needed to be renamed(interchanged) because the `application-sentry-dsn.yaml` has logic to add sentry-dsn for a cronjob and vice versa for `cronjob-sentry-dsn.yaml`.
+The `application-sentry-dsn.yaml` and `cronjob-sentry-dsn.yaml` files needed to be renamed(interchanged) because the `application-sentry-dsn.yaml` has logic to add sentry-dsn for a cronjob and vice versa for `cronjob-sentry-dsn.yaml`. Files have been renamed now to correctly generate sealedsecrets.
 
 ## [2.3.0] - 2021-11-05
 

--- a/charts/aruba-uxi/Chart.yaml
+++ b/charts/aruba-uxi/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: aruba-uxi
 description: A Helm chart for Aruba UXI kubernetes resources
 type: application
-version: 2.3.0
+version: 2.3.1
 maintainers:
   - name: Aruba-UXI

--- a/charts/aruba-uxi/templates/application-sentry-dsn.yaml
+++ b/charts/aruba-uxi/templates/application-sentry-dsn.yaml
@@ -1,9 +1,9 @@
-{{- range $name, $data := .Values.cronjobs }}
+{{- range $name, $data := .Values.applications }}
 {{- $sentry := default dict $data.sentry }}
 {{- $additionalLabels := deepCopy (default dict $.Values.global.labels) | mustMerge (default dict $data.labels) }}
 {{- if $sentry.enabled }}
 {{- if not $sentry.dsn }}
-{{- fail (printf "Sentry is enabled but cronjobs.%s.sentry.dsn is not defined" $name) }}
+{{- fail (printf "Sentry is enabled but applications.%s.sentry.dsn is not defined" $name) }}
 {{- end}}
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret

--- a/charts/aruba-uxi/templates/cronjob-sentry-dsn.yaml
+++ b/charts/aruba-uxi/templates/cronjob-sentry-dsn.yaml
@@ -1,9 +1,9 @@
-{{- range $name, $data := .Values.applications }}
+{{- range $name, $data := .Values.cronjobs }}
 {{- $sentry := default dict $data.sentry }}
 {{- $additionalLabels := deepCopy (default dict $.Values.global.labels) | mustMerge (default dict $data.labels) }}
 {{- if $sentry.enabled }}
 {{- if not $sentry.dsn }}
-{{- fail (printf "Sentry is enabled but applications.%s.sentry.dsn is not defined" $name) }}
+{{- fail (printf "Sentry is enabled but cronjobs.%s.sentry.dsn is not defined" $name) }}
 {{- end}}
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret

--- a/examples/aruba-uxi-example/output-local.yaml
+++ b/examples/aruba-uxi-example/output-local.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -46,7 +46,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-2.3.0
+        helm.sh/chart: aruba-uxi-2.3.1
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -36,7 +36,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -60,7 +60,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -85,7 +85,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -103,7 +103,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-2.3.0
+        helm.sh/chart: aruba-uxi-2.3.1
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -219,7 +219,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -236,7 +236,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-worker
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-2.3.0
+        helm.sh/chart: aruba-uxi-2.3.1
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -283,7 +283,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-consumer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -331,7 +331,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -393,7 +393,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -416,28 +416,11 @@ spec:
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  name: example-cronjob-producer-sentry-dsn
-  labels:
-    app.kubernetes.io/name: example-cronjob-producer
-    app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
-    app.kubernetes.io/managed-by: Helm
-    repository: aruba-uxi-example
-    namespace: default
-    global-label: global-label
-spec:
-  encryptedData:
-    SENTRY_DSN: sealed_version_of_the_base64_encoded_example_cronjob_producer_sentry_dsn
----
-# Source: aruba-uxi-example/charts/aruba-uxi/templates/cronjob-sentry-dsn.yaml
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
   name: example-service-sentry-dsn
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -447,6 +430,23 @@ spec:
   encryptedData:
     SENTRY_DSN: sealed_version_of_the_base64_encoded_example_service_sentry_dsn
 ---
+# Source: aruba-uxi-example/charts/aruba-uxi/templates/cronjob-sentry-dsn.yaml
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: example-cronjob-producer-sentry-dsn
+  labels:
+    app.kubernetes.io/name: example-cronjob-producer
+    app.kubernetes.io/instance: aruba-uxi-example
+    helm.sh/chart: aruba-uxi-2.3.1
+    app.kubernetes.io/managed-by: Helm
+    repository: aruba-uxi-example
+    namespace: default
+    global-label: global-label
+spec:
+  encryptedData:
+    SENTRY_DSN: sealed_version_of_the_base64_encoded_example_cronjob_producer_sentry_dsn
+---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/imagepullsecret.yaml
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
@@ -454,7 +454,7 @@ metadata:
   name: sealed-image-pull-secret
   labels:
     app.kubernetes.io/name: sealed-image-pull-secret
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     namespace: default
 spec:
@@ -466,7 +466,7 @@ spec:
       name: sealed-image-pull-secret
       labels:
       app.kubernetes.io/name: sealed-image-pull-secret
-      helm.sh/chart: aruba-uxi-2.3.0
+      helm.sh/chart: aruba-uxi-2.3.1
       app.kubernetes.io/managed-by: Helm
       namespace: default
     type: kubernetes.io/dockerconfigjson
@@ -479,7 +479,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-access
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -496,7 +496,7 @@ metadata:
   labels:
     app.kubernetes.io/name: database-url
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-2.3.0
+    helm.sh/chart: aruba-uxi-2.3.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default


### PR DESCRIPTION
## Description
- The `application-sentry-dsn.yaml` and `cronjob-sentry-dsn.yaml` file had logics interchanged earlier thus not creating sealed secrets correctly.

## Types of changes

_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code removal (deleting unused / redundant code)
- [ ] Documentation update (if none of the other choices apply)

## Further Information
N/A