### PR TITLE
fix: correct ingress fields for extensions/v1beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Use extensions/v1beta1 for ingresses because networking.k8s.io/v1 is incompatible with prod
 - Update ingress config to align with extensions/v1beta1
+- Remove pathType from ingress
 
 ## [3.0.2] - 2022-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - what has been changed
 
+## [3.0.3] - 2022-02-15
+
+### Changed
+
+- Use extensions/v1beta1 for ingresses because networking.k8s.io/v1 is incompatible with prod
+- Update ingress config to align with extensions/v1beta1
+
 ## [3.0.2] - 2022-02-15
 
 ### Changed

--- a/charts/aruba-uxi/Chart.yaml
+++ b/charts/aruba-uxi/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: aruba-uxi
 description: A Helm chart for Aruba UXI kubernetes resources
 type: application
-version: 3.0.2
+version: 3.0.3
 maintainers:
   - name: Aruba-UXI

--- a/charts/aruba-uxi/README.md
+++ b/charts/aruba-uxi/README.md
@@ -145,7 +145,6 @@ In this table `application` refers to each application defined under `applicatio
 | application.ingress.hosts | A list of hosts to add to the legacy ingress. | `[]` | Yes |
 | application.ingress.hosts[].paths | A list of paths for each legacy ingress hosts | `[]` | Yes |
 | application.ingress.hosts[].paths.path | The path | `/` | Yes |
-| application.ingress.hosts[].paths.pathType | The path type | `ImplementationSpecific` | Yes |
 | application.ingress.hosts[].paths.backend.serviceName | The service name that the path talks to. | `application.name` | Yes |
 | application.ingress.hosts[].paths.backend.servicePort | The service port that the path talks to. | `application.port` | Yes |
 | application.ingress.tls | A set of TLS configuration settings to add to the lagacy ingress. | `[]` | Yes |

--- a/charts/aruba-uxi/templates/application-ingress.yaml
+++ b/charts/aruba-uxi/templates/application-ingress.yaml
@@ -31,13 +31,16 @@ spec:
       - path: {{ $path.path }}
         pathType: {{ default "ImplementationSpecific" $path.pathTpe }}
         backend:
-          {{- if $path.backend }}
-          serviceName: {{ default $name $path.backend.serviceName }}
-          servicePort: {{ default 80 $path.backend.servicePort }}
-          {{- else }}
-          serviceName: {{ $name }}
-          servicePort: {{ default 80 $service.port }}
-          {{- end }}
+          service:
+            {{- if $path.backend }}
+            name: {{ default $name $path.backend.serviceName }}
+            port:
+              number: {{ default 80 $path.backend.servicePort }}
+            {{- else }}
+            name: {{ $name }}
+            port:
+              number: {{ default 80 $service.port }}
+            {{- end }}
       {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/aruba-uxi/templates/application-ingress.yaml
+++ b/charts/aruba-uxi/templates/application-ingress.yaml
@@ -32,9 +32,6 @@ spec:
       paths:
       {{- range $path := .paths }}
       - path: {{ $path.path }}
-        {{- if $path.pathType }}
-        pathType: {{ $path.pathTpe }}
-        {{- end }}
         backend:
           {{- if $path.backend }}
           serviceName: {{ default $name $path.backend.serviceName }}

--- a/charts/aruba-uxi/templates/application-ingress.yaml
+++ b/charts/aruba-uxi/templates/application-ingress.yaml
@@ -4,7 +4,7 @@
 {{- $service := default dict $data.service }}
 {{- $additionalLabels := deepCopy (default dict $.Values.global.labels) | mustMerge (default dict $data.labels) }}
 {{- if $ingress.enabled -}}
-apiVersion: networking.k8s.io/v1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $name }}

--- a/charts/aruba-uxi/templates/application-ingress.yaml
+++ b/charts/aruba-uxi/templates/application-ingress.yaml
@@ -10,8 +10,11 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "aruba-uxi.labels" (dict "context" $ "name" $name "additionalLabels" $additionalLabels) | nindent 4 }}
+  {{- if $ingress.className }}
+  annotations:
+    kubernetes.io/ingress.class: {{ $ingress.className }}
+  {{- end }}
 spec:
-  ingressClassName: {{ default "nginx" $ingress.className }}
   {{- if $ingress.tls }}
   tls:
   {{- range $ingress.tls }}
@@ -29,18 +32,17 @@ spec:
       paths:
       {{- range $path := .paths }}
       - path: {{ $path.path }}
-        pathType: {{ default "ImplementationSpecific" $path.pathTpe }}
+        {{- if $path.pathType }}
+        pathType: {{ $path.pathTpe }}
+        {{- end }}
         backend:
-          service:
-            {{- if $path.backend }}
-            name: {{ default $name $path.backend.serviceName }}
-            port:
-              number: {{ default 80 $path.backend.servicePort }}
-            {{- else }}
-            name: {{ $name }}
-            port:
-              number: {{ default 80 $service.port }}
-            {{- end }}
+          {{- if $path.backend }}
+          serviceName: {{ default $name $path.backend.serviceName }}
+          servicePort: {{ default 80 $path.backend.servicePort }}
+          {{- else }}
+          serviceName: {{ $name }}
+          servicePort: {{ default 80 $service.port }}
+          {{- end }}
       {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/aruba-uxi/values.example.yaml
+++ b/charts/aruba-uxi/values.example.yaml
@@ -221,7 +221,6 @@ aruba-uxi:
         - host: example-service.local
           paths:
           - path: /
-            pathType: ImplementationSpecific
             backend:
               serviceName: example-service
               servicePort: 8000

--- a/examples/aruba-uxi-example/output-local.yaml
+++ b/examples/aruba-uxi-example/output-local.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -46,7 +46,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-3.0.2
+        helm.sh/chart: aruba-uxi-3.0.3
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -372,19 +372,17 @@ metadata:
     namespace: default
     example-service-staging: example-service-staging
     global-label: global-label
+  annotations:
+    kubernetes.io/ingress.class: nginx
 spec:
-  ingressClassName: nginx
   rules:
   - host: example-service.staging.capedev.io
     http:
       paths:
       - path: /
-        pathType: ImplementationSpecific
         backend:
-          service:
-            name: example-service
-            port:
-              number: 80
+          serviceName: example-service
+          servicePort: 80
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-sentry-dsn.yaml
 apiVersion: bitnami.com/v1alpha1

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -359,7 +359,7 @@ spec:
           restartPolicy: OnFailure
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-ingress.yaml
-apiVersion: networking.k8s.io/v1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: example-service

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -36,7 +36,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -60,7 +60,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -85,7 +85,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -103,7 +103,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-3.0.2
+        helm.sh/chart: aruba-uxi-3.0.3
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -221,7 +221,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -238,7 +238,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-worker
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-3.0.2
+        helm.sh/chart: aruba-uxi-3.0.3
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -278,7 +278,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-consumer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -325,7 +325,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -366,7 +366,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -381,8 +381,10 @@ spec:
       - path: /
         pathType: ImplementationSpecific
         backend:
-          serviceName: example-service
-          servicePort: 80
+          service:
+            name: example-service
+            port:
+              number: 80
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-sentry-dsn.yaml
 apiVersion: bitnami.com/v1alpha1
@@ -392,7 +394,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -410,7 +412,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -426,7 +428,7 @@ metadata:
   name: aruba-uxi-example-image-pull-secret
   labels:
     app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     namespace: default
 spec:
@@ -438,7 +440,7 @@ spec:
       name: aruba-uxi-example-image-pull-secret
       labels:
       app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-      helm.sh/chart: aruba-uxi-3.0.2
+      helm.sh/chart: aruba-uxi-3.0.3
       app.kubernetes.io/managed-by: Helm
       namespace: default
     type: kubernetes.io/dockerconfigjson
@@ -451,7 +453,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-access
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -468,7 +470,7 @@ metadata:
   labels:
     app.kubernetes.io/name: database-url
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -484,7 +486,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service-account
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.2
+    helm.sh/chart: aruba-uxi-3.0.3
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default

--- a/examples/aruba-uxi-example/values-staging.yaml
+++ b/examples/aruba-uxi-example/values-staging.yaml
@@ -76,6 +76,7 @@ aruba-uxi:
       labels:
         example-service-staging: example-service-staging
       ingress:
+        className: nginx
         enabled: true
         hosts:
         - host: example-service.staging.capedev.io


### PR DESCRIPTION
## Description

It looks like the previous config was using a mixture of fields expected from extensions/v1beta1 and networking.k8s.io/v1, this aligns the fields to only be expecting extentions/v1beta1. 

The config was adjusted based on the output of

```kubectl explain --api-version=extensions/v1beta1 ingress --recursive | less```

## Types of changes

_Put an `x` in the boxes that apply._

- [x] Bugfix (`fix`): A non-breaking change which fixes an issue or bug
- [ ] New Feature (`feat`): A non-breaking change which adds a new feature or new functionality
- [ ] Tests (`test`): Adding missing tests or correcting existing tests
- [ ] Refactoring (`refactor`): A code change that neither fixes a bug nor adds a feature, e.g Deleting unused or redundant code
- [ ] Documentation (`docs`): Documentation only changes
- [ ] Other (`style`, `build`, `ci`, `performance`): Formatting, linting or styling. Changes to the CI pipeline. Performance improvements. Changes that affect the build system.

## Further Information

JIRA Ticket: <https://uxi.atlassian.net/browse/BEP-XXX>

Any relevant logs, screenshots, testing output, etc...
