### PR TITLE
feat: remove ingress.enabled value, define different ingress versions

### DIFF
--- a/.github/workflows/change-log.yaml
+++ b/.github/workflows/change-log.yaml
@@ -7,28 +7,28 @@ jobs:
     name: Change Log Check
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v2
+      - name: Checkout Code
+        uses: actions/checkout@v2
 
-    - name: Git Fetch
-      run: |
-        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+      - name: Git Fetch
+        run: |
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
 
-    - name: Main Version Number
-      run: echo "::set-output name=result::$(git show origin/main:charts/aruba-uxi/Chart.yaml | yq e .version -)"
-      id: main_version_number
+      - name: Main Version Number
+        run: echo "::set-output name=result::$(git show origin/main:charts/aruba-uxi/Chart.yaml | yq e .version -)"
+        id: main_version_number
 
-    - name: Branch Version Number
-      run: echo "::set-output name=result::$(yq e .version charts/aruba-uxi/Chart.yaml)"
-      id: branch_version_number
+      - name: Branch Version Number
+        run: echo "::set-output name=result::$(yq e .version charts/aruba-uxi/Chart.yaml)"
+        id: branch_version_number
 
-    - name: Git Diff CHANGELOG.md
-      run: |
-        echo "::set-output name=result::$(git diff --name-only --exit-code origin/main..HEAD -- CHANGELOG.md)"
-      id: has_changelog_changes
+      - name: Git Diff CHANGELOG.md
+        run: |
+          echo "::set-output name=result::$(git diff --name-only --exit-code origin/main..HEAD -- CHANGELOG.md)"
+        id: has_changelog_changes
 
-    - name: Verify Values Tag == Chart Version
-      if: ${{ steps.main_version_number.outputs.result != steps.branch_version_number.outputs.result && !steps.has_changelog_changes.outputs.result }}
-      run: |
-        echo "Chart changes were detected but no changes to CHANGELOG.md were found. Please document the change"
-        exit 1
+      - name: Verify Values Tag == Chart Version
+        if: ${{ steps.main_version_number.outputs.result != steps.branch_version_number.outputs.result && !steps.has_changelog_changes.outputs.result }}
+        run: |
+          echo "Chart changes were detected but no changes to CHANGELOG.md were found. Please document the change"
+          exit 1

--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -51,3 +51,4 @@ jobs:
           just output
           git diff --exit-code -- examples/aruba-uxi-example/output-local.yaml
           git diff --exit-code -- examples/aruba-uxi-example/output-staging.yaml
+          git diff --exit-code -- examples/aruba-uxi-example/output-production.yaml

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,10 @@
+extends: default
+
+rules:
+  line-length:
+    max: 100
+  document-start: disable
+
+ignore: |
+  /.github/
+  /venv*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - what has been changed
 
+## [3.0.4] - 2022-02-22
+
+### Changed
+
+The ability to use a legacy `apiVersion` for the ingress object. This is to cater for production using an outdate version of kubernetes.
+Staging and Production can not use the same ingress object.
+
 ## [3.0.3] - 2022-02-15
 
 ### Changed

--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,7 @@ help:
 output:
 	just template-aruba-uxi-local "> examples/aruba-uxi-example/output-local.yaml"
 	just template-aruba-uxi-staging "> examples/aruba-uxi-example/output-staging.yaml"
+	just template-aruba-uxi-production "> examples/aruba-uxi-example/output-production.yaml"
 
 # Render helm templates for aruba-uxi example local
 template-aruba-uxi-local +ARGS='':
@@ -16,3 +17,8 @@ template-aruba-uxi-local +ARGS='':
 template-aruba-uxi-staging +ARGS='':
 	helm dependency update examples/aruba-uxi-example
 	helm template aruba-uxi-example examples/aruba-uxi-example -f examples/aruba-uxi-example/values-staging.yaml {{ARGS}}
+
+# Render helm templates for aruba-uxi example production
+template-aruba-uxi-production +ARGS='':
+	helm dependency update examples/aruba-uxi-example
+	helm template aruba-uxi-example examples/aruba-uxi-example -f examples/aruba-uxi-example/values-production.yaml {{ARGS}}

--- a/charts/aruba-uxi/Chart.yaml
+++ b/charts/aruba-uxi/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: aruba-uxi
 description: A Helm chart for Aruba UXI kubernetes resources
 type: application
-version: 3.0.3
+version: 3.1.0
 maintainers:
   - name: Aruba-UXI

--- a/charts/aruba-uxi/README.md
+++ b/charts/aruba-uxi/README.md
@@ -15,7 +15,7 @@ Typically the `values.yaml` file defines the base values used by helm, and then 
 
 When using this chart library its best to leave the `values.yaml` files empty and define separate values for each environment.
 
-> ****NOTE:**** Yes this does go against helm convention but its the best way we can do that does not cause duplicate data. Environment variables proved to be a bit tricky because in the local environment DATABASE_URL for example, could be defined in `.env` then in the staging environment it moves to `.envSealedSecrets`. It proved too hard to remove the duplicate values, so its best not to define any environment variables in the `values.yaml`.
+> **NOTE:** Yes this does go against helm convention but its the best way we can do that does not cause duplicate data. Environment variables proved to be a bit tricky because in the local environment DATABASE_URL for example, could be defined in `.env` then in the staging environment it moves to `.envSealedSecrets`. It proved too hard to remove the duplicate values, so its best not to define any environment variables in the `values.yaml`.
 
 It is possible to define some values in the `values.yaml` file. You are welcome to experiment with defining the some values in the `values.yaml` file and overriding them in the environment values file.
 
@@ -38,7 +38,7 @@ Follow the instructions in the [Sealed Secrets Wiki](https://github.com/aruba-ux
 
 When naming a sealed secret you need to ensure that the name you use to create the sealed secret and the name you give in the values file is the same.
 
-> ****NOTE:**** The `sealedSecrets.imagePullSecret` name should be called `uxi-sealed-image-pull-secret`
+> **NOTE:** The `sealedSecrets.imagePullSecret` name should be called `uxi-sealed-image-pull-secret`
 
 Once you have created a `SealedSecret` you will need to copy the encoded value for each key defined.
 
@@ -81,7 +81,7 @@ Global values used by all kubernetes objects. The `Can Override` column in the t
 | global.envSealedSecrets | Environment variables from sealed secrets. Precedence is given to the overridden values. | `{}` | Yes | Yes |
 | global.labels | Extra labels to apply to all k8s objects (excluding `sealedSecrets.imagePullSecret`). | `{}` | Yes | Yes |
 
-> ****NOTE:**** The `.global.image.tag` is required in the `values.yaml` file but is option in all overlays.
+> **NOTE:** The `.global.image.tag` is required in the `values.yaml` file but is option in all overlays.
 
 ### Application Values
 

--- a/charts/aruba-uxi/README.md
+++ b/charts/aruba-uxi/README.md
@@ -15,7 +15,7 @@ Typically the `values.yaml` file defines the base values used by helm, and then 
 
 When using this chart library its best to leave the `values.yaml` files empty and define separate values for each environment.
 
-> **__NOTE:__** Yes this does go against helm convention but its the best way we can do that does not cause duplicate data. Environment variables proved to be a bit tricky because in the local environment DATABASE_URL for example, could be defined in `.env` then in the staging environment it moves to `.envSealedSecrets`. It proved too hard to remove the duplicate values, so its best not to define any environment variables in the `values.yaml`.
+> \***\*NOTE:\*\*** Yes this does go against helm convention but its the best way we can do that does not cause duplicate data. Environment variables proved to be a bit tricky because in the local environment DATABASE_URL for example, could be defined in `.env` then in the staging environment it moves to `.envSealedSecrets`. It proved too hard to remove the duplicate values, so its best not to define any environment variables in the `values.yaml`.
 
 It is possible to define some values in the `values.yaml` file. You are welcome to experiment with defining the some values in the `values.yaml` file and overriding them in the environment values file.
 
@@ -23,168 +23,161 @@ It is possible to define some values in the `values.yaml` file. You are welcome 
 
 ```yaml
 aruba-uxi:
-  sealedSecrets:
-    ...
+    sealedSecrets: ...
 ```
 
 Sealed secrets are defined with the `.sealedSecrets` object. A `SealedSecret` kubernetes object is created using the data defined in this map.
 
-| Parameter | Description | Default | Optional |
-|-----|------|---------|---|
-| sealedSecrets.imagePullSecret | The sealed version of the base64 encoded `dockerconfigjson` file used to provide access to our image repository | "" | Yes |
-| sealedSecrets.env | Sealed secrets used to populate environment variables in the applications and containers. A sealed secret is created for each key in the dictionary. See [values.example.yaml](https://github.com/Aruba-UXI/chart-library/blob/main/examples/aruba-uxi-example/values.example.yaml) for usage| {} | Yes |
+| Parameter                     | Description                                                                                                                                                                                                                                                                                   | Default | Optional |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| sealedSecrets.imagePullSecret | The sealed version of the base64 encoded `dockerconfigjson` file used to provide access to our image repository                                                                                                                                                                               | ""      | Yes      |
+| sealedSecrets.env             | Sealed secrets used to populate environment variables in the applications and containers. A sealed secret is created for each key in the dictionary. See [values.example.yaml](https://github.com/Aruba-UXI/chart-library/blob/main/examples/aruba-uxi-example/values.example.yaml) for usage | {}      | Yes      |
 
 Follow the instructions in the [Sealed Secrets Wiki](https://github.com/aruba-uxi/knowledge/wiki/Sealed-Secrets) to create a `SealedSecret`.
 
 When naming a sealed secret you need to ensure that the name you use to create the sealed secret and the name you give in the values file is the same.
 
-> **__NOTE:__** The `sealedSecrets.imagePullSecret` name should be called `uxi-sealed-image-pull-secret`
+> \***\*NOTE:\*\*** The `sealedSecrets.imagePullSecret` name should be called `uxi-sealed-image-pull-secret`
 
 Once you have created a `SealedSecret` you will need to copy the encoded value for each key defined.
 
 For example, to create a sealed secret called `database-url` with the key `DATABASE_URL`, you need to follow the instructions in the link above to create a sealed secret with the following values:
 
-- name: `database-url`
-- key `DATABASE_URL`
-- value: The value is the URL taken from wherever the database is hosted
-- namespace: The namespace should be the name of the github repo, unless there are reasons for it to
+-   name: `database-url`
+-   key `DATABASE_URL`
+-   value: The value is the URL taken from wherever the database is hosted
+-   namespace: The namespace should be the name of the github repo, unless there are reasons for it to
 
 The output should be a sealed secret with an encoded string for the `DATABASE_URL` value. Copy this value and paste it into the values file in the correct section.
 
 ```yaml
 aruba-uxi:
-  sealedSecrets:
-    env:
-      database-url:
-        DATABASE_URL: sealed_version_of_the_base64_encoded_database_url
+    sealedSecrets:
+        env:
+            database-url:
+                DATABASE_URL: sealed_version_of_the_base64_encoded_database_url
 ```
 
 ### Global Values
 
 ```yaml
 aruba-uxi:
-  global:
-    ...
+    global: ...
 ```
 
 Global values used by all kubernetes objects. The `Can Override` column in the table identifies which values can be overridden by the applications or cronjobs.
 
-| Parameter | Description | Default | Optional | Can Override |
-|-----|------|---------|---|---|
-| global.repository | The github repository that these charts are kept in | | No | No |
-| global.environment | The environment that the service is being deployed to. Values are converted to lowercase when used. Validation is also done on the values. Valid environments are (`DEV`, `STAGING`, `PRODUCTION`) | | No | No |
-| global.image.repository | The image repository to use for images. | | No | Yes |
-| global.image.tag | The image tag to use. | | No | Yes |
-| global.image.imagePullPolicy | The image pull policy to use. | `"IfNotPresent"` | Yes | Yes |
-| global.env | Basic environment variables. Precedence is given to the overridden values | `{}` | Yes | Yes |
-| global.envFields | Environment variables that pull information from kubernetss object fields. Precedence is given to the overridden values | `{}` | Yes |  Yes |
-| global.envSealedSecrets | Environment variables from sealed secrets. Precedence is given to the overridden values. | `{}` | Yes | Yes |
-| global.labels | Extra labels to apply to all k8s objects (excluding `sealedSecrets.imagePullSecret`). | `{}` | Yes | Yes |
+| Parameter                    | Description                                                                                                                                                                                        | Default          | Optional | Can Override |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- | ------------ |
+| global.repository            | The github repository that these charts are kept in                                                                                                                                                |                  | No       | No           |
+| global.environment           | The environment that the service is being deployed to. Values are converted to lowercase when used. Validation is also done on the values. Valid environments are (`DEV`, `STAGING`, `PRODUCTION`) |                  | No       | No           |
+| global.image.repository      | The image repository to use for images.                                                                                                                                                            |                  | No       | Yes          |
+| global.image.tag             | The image tag to use.                                                                                                                                                                              |                  | No       | Yes          |
+| global.image.imagePullPolicy | The image pull policy to use.                                                                                                                                                                      | `"IfNotPresent"` | Yes      | Yes          |
+| global.env                   | Basic environment variables. Precedence is given to the overridden values                                                                                                                          | `{}`             | Yes      | Yes          |
+| global.envFields             | Environment variables that pull information from kubernetss object fields. Precedence is given to the overridden values                                                                            | `{}`             | Yes      | Yes          |
+| global.envSealedSecrets      | Environment variables from sealed secrets. Precedence is given to the overridden values.                                                                                                           | `{}`             | Yes      | Yes          |
+| global.labels                | Extra labels to apply to all k8s objects (excluding `sealedSecrets.imagePullSecret`).                                                                                                              | `{}`             | Yes      | Yes          |
 
-> **__NOTE:__** The `.global.image.tag` is required in the `values.yaml` file but is option in all overlays.
+> \***\*NOTE:\*\*** The `.global.image.tag` is required in the `values.yaml` file but is option in all overlays.
 
 ### Application Values
 
 ```yaml
 aruba-uxi:
-  applications:
-    example-webapp:
-      ...
-    example-worker:
-      ...
+    applications:
+        example-webapp: ...
+        example-worker: ...
 ```
 
 In this table `application` refers to each application defined under `applications`
 
-| Parameter | Description | Default | Optional |
-|-----|------|---------|--------|
-| application.role | The role that this application will serve. Validation is done to make sure the correct role is provided. Valid roles are (`webapp`, `worker`) | | No |
-| application.revisionHistoryLimit | The number of old ReplicaSets to be retained | `3` | Yes |
-| application.replicaCount | The number of pod replicas to create | `1` | Yes |
-| application.image.repository | A specific image that the application should use | `globals.image.repository` | Yes |
-| application.image.tag | The image to use for this specific application | `globals.image.tag` | Yes |
-| application.image.pullPolicy | The image pull policy to use for this application | `globals.image.pullPOlicy` | Yes |
-| application.serviceAccount.create | Creates a service account and adds it to the application. If no name is provided the application name will be used | `false` | Yes |
-| application.serviceAccount.name | The name of the service account to attach to this application| | Yes |
-| application.serviceAccount.annotations | Any annotations to add the service account that is created | | Yes |
-| application.command | The command that the pod must run. Overrides the docker image command | `""` | Yes |
-| application.args | The arguments that used by the override command | `""` | Yes |
-| application.port | The port that must be exposed on the pod. Also used when adding a service to the webapp. Can be excluded when defining a worker | | No |
-| application.service | Configures the service created for webapps | `ClusterIP` | Yes |
-| application.service.type | Configures the service type that is created for webapps | `ClusterIP` | Yes |
-| application.service.port | Configures the service port to expose | `80` | Yes |
-| application.livenessProbe.path | The API path to query for liveness tests | `/livez` | Yes |
-| application.readinessProbe.path | The API path to query for readiness tests | `/readyz` | Yes |
-| application.livenessProbe.command | The command to use to test liveness (as opposed to livenessProbe.path) | | Yes |
-| application.readinessProbe.command | The command to use to test readiness (as opposed to readinessProbe.path)| | Yes |
-| application.resources | Resource limits and requests to set on the pod. See [link](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more details on the structure | `{}` | Yes |
-| application.nodeSelector | Node selector specifications to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for more details on the structure | `{}` | Yes |
-| application.tolerations | Tolerations to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more details on the structure | `{}` | Yes |
-| application.affinity | Affinity to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for more details on the structure | `{}` | Yes |
-| application.securityContext | Sets the security contextfor the pods. See [link](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for more details on the structure | `{}` | Yes |
-| application.configMap | A config map to create and apply to the application | | Yes |
-| application.configMap.annotations | Annotations to add to the config map | `{}` | Yes |
-| application.configMap.readOnly | Whether the configmap is mapped as readonly or not | `true` | Yes |
-| application.configMap.path | The path to map the config map to in the pod | `{}` | Yes |
-| application.configMap.data | The data to add to the config map | `{}` | Yes |
-| application.secretMount | A secret mount to add secrets as a file to the pod | | Yes |
-| application.secretMount.name | The name of the secret volume to be mounted | | Yes |
-| application.secretMount.path | The path to mount the secret on in the pod | `{}` | Yes |
-| application.secretMount.readOnly | Whether the secret is mounted as readonly file or not | `true` | Yes |
-| application.env | Basic environment variables specific for this application. Can override the global.env values | `{}` | Yes |
-| application.envFields | Environment variables that pull information from kubernetss object fields for this application. Can override the global.envField values | `{}` | Yes |
-| application.envSealedSecrets | Environment variables from sealed secrets specific to this application. Can override the global.envSealedSecrets values | `{}` | Yes |
-| application.datadog.enabled | Enables datadog metrics. Setting to true will create the necessary environment variables | `false` | Yes |
-| application.datadog.traceEnabled | Enables datadog tracing. | `false` | Yes |
-| application.sentry.enabled | Enables sentry on the application. Setting to true will create the necessary environment variables. You need to add the `.sentry.dsn` value to create the sentry DSN sealed secret | `false` | Yes |
-| application.sentry.dsn | Creates a sealed secret with the sentry DSN from the provided sealed version of the base64 encoded sentry DSN value. The sealed secret name takes the format `<application-name>-sentry-dsn` | | Yes |
-| application.labels | Extra labels to apply to all k8s objects. Includes any extra labels defined in the global object. | `{}` | Yes |
-| application.ingress | Configures the legacy ingress added to an application | `{}` | Yes |
-| application.ingress.enabled | Enables the legacy ingress on the application. Setting to true will create a new legacy ingress manifest. | `false` | Yes |
-| application.ingress.className | Defines the ingressClassName. | `nginx` | Yes |
-| application.ingress.hosts | A list of hosts to add to the legacy ingress. | `[]` | Yes |
-| application.ingress.hosts[].paths | A list of paths for each legacy ingress hosts | `[]` | Yes |
-| application.ingress.hosts[].paths.path | The path | `/` | Yes |
-| application.ingress.hosts[].paths.backend.serviceName | The service name that the path talks to. | `application.name` | Yes |
-| application.ingress.hosts[].paths.backend.servicePort | The service port that the path talks to. | `application.port` | Yes |
-| application.ingress.tls | A set of TLS configuration settings to add to the lagacy ingress. | `[]` | Yes |
-| application.ingress.tls.secretName | The secret that contains the TLS certs. | | Yes |
-| application.ingress.tls.hosts | The hosts which use the TLS certs contained in the respective secret. | | Yes |
+| Parameter                                             | Description                                                                                                                                                                                  | Default                    | Optional |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------- |
+| application.role                                      | The role that this application will serve. Validation is done to make sure the correct role is provided. Valid roles are (`webapp`, `worker`)                                                |                            | No       |
+| application.revisionHistoryLimit                      | The number of old ReplicaSets to be retained                                                                                                                                                 | `3`                        | Yes      |
+| application.replicaCount                              | The number of pod replicas to create                                                                                                                                                         | `1`                        | Yes      |
+| application.image.repository                          | A specific image that the application should use                                                                                                                                             | `globals.image.repository` | Yes      |
+| application.image.tag                                 | The image to use for this specific application                                                                                                                                               | `globals.image.tag`        | Yes      |
+| application.image.pullPolicy                          | The image pull policy to use for this application                                                                                                                                            | `globals.image.pullPOlicy` | Yes      |
+| application.serviceAccount.create                     | Creates a service account and adds it to the application. If no name is provided the application name will be used                                                                           | `false`                    | Yes      |
+| application.serviceAccount.name                       | The name of the service account to attach to this application                                                                                                                                |                            | Yes      |
+| application.serviceAccount.annotations                | Any annotations to add the service account that is created                                                                                                                                   |                            | Yes      |
+| application.command                                   | The command that the pod must run. Overrides the docker image command                                                                                                                        | `""`                       | Yes      |
+| application.args                                      | The arguments that used by the override command                                                                                                                                              | `""`                       | Yes      |
+| application.port                                      | The port that must be exposed on the pod. Also used when adding a service to the webapp. Can be excluded when defining a worker                                                              |                            | No       |
+| application.service                                   | Configures the service created for webapps                                                                                                                                                   | `ClusterIP`                | Yes      |
+| application.service.type                              | Configures the service type that is created for webapps                                                                                                                                      | `ClusterIP`                | Yes      |
+| application.service.port                              | Configures the service port to expose                                                                                                                                                        | `80`                       | Yes      |
+| application.livenessProbe.path                        | The API path to query for liveness tests                                                                                                                                                     | `/livez`                   | Yes      |
+| application.readinessProbe.path                       | The API path to query for readiness tests                                                                                                                                                    | `/readyz`                  | Yes      |
+| application.livenessProbe.command                     | The command to use to test liveness (as opposed to livenessProbe.path)                                                                                                                       |                            | Yes      |
+| application.readinessProbe.command                    | The command to use to test readiness (as opposed to readinessProbe.path)                                                                                                                     |                            | Yes      |
+| application.resources                                 | Resource limits and requests to set on the pod. See [link](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more details on the structure                 | `{}`                       | Yes      |
+| application.nodeSelector                              | Node selector specifications to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for more details on the structure          | `{}`                       | Yes      |
+| application.tolerations                               | Tolerations to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more details on the structure                                   | `{}`                       | Yes      |
+| application.affinity                                  | Affinity to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for more details on the structure                | `{}`                       | Yes      |
+| application.securityContext                           | Sets the security contextfor the pods. See [link](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for more details on the structure                              | `{}`                       | Yes      |
+| application.configMap                                 | A config map to create and apply to the application                                                                                                                                          |                            | Yes      |
+| application.configMap.annotations                     | Annotations to add to the config map                                                                                                                                                         | `{}`                       | Yes      |
+| application.configMap.readOnly                        | Whether the configmap is mapped as readonly or not                                                                                                                                           | `true`                     | Yes      |
+| application.configMap.path                            | The path to map the config map to in the pod                                                                                                                                                 | `{}`                       | Yes      |
+| application.configMap.data                            | The data to add to the config map                                                                                                                                                            | `{}`                       | Yes      |
+| application.secretMount                               | A secret mount to add secrets as a file to the pod                                                                                                                                           |                            | Yes      |
+| application.secretMount.name                          | The name of the secret volume to be mounted                                                                                                                                                  |                            | Yes      |
+| application.secretMount.path                          | The path to mount the secret on in the pod                                                                                                                                                   | `{}`                       | Yes      |
+| application.secretMount.readOnly                      | Whether the secret is mounted as readonly file or not                                                                                                                                        | `true`                     | Yes      |
+| application.env                                       | Basic environment variables specific for this application. Can override the global.env values                                                                                                | `{}`                       | Yes      |
+| application.envFields                                 | Environment variables that pull information from kubernetss object fields for this application. Can override the global.envField values                                                      | `{}`                       | Yes      |
+| application.envSealedSecrets                          | Environment variables from sealed secrets specific to this application. Can override the global.envSealedSecrets values                                                                      | `{}`                       | Yes      |
+| application.datadog.enabled                           | Enables datadog metrics. Setting to true will create the necessary environment variables                                                                                                     | `false`                    | Yes      |
+| application.datadog.traceEnabled                      | Enables datadog tracing.                                                                                                                                                                     | `false`                    | Yes      |
+| application.sentry.enabled                            | Enables sentry on the application. Setting to true will create the necessary environment variables. You need to add the `.sentry.dsn` value to create the sentry DSN sealed secret           | `false`                    | Yes      |
+| application.sentry.dsn                                | Creates a sealed secret with the sentry DSN from the provided sealed version of the base64 encoded sentry DSN value. The sealed secret name takes the format `<application-name>-sentry-dsn` |                            | Yes      |
+| application.labels                                    | Extra labels to apply to all k8s objects. Includes any extra labels defined in the global object.                                                                                            | `{}`                       | Yes      |
+| application.ingress                                   | Configures the legacy ingress added to an application                                                                                                                                        | `{}`                       | Yes      |
+| application.ingress.className                         | Defines the ingressClassName.                                                                                                                                                                | `nginx`                    | Yes      |
+| application.ingress.hosts                             | A list of hosts to add to the legacy ingress.                                                                                                                                                | `[]`                       | Yes      |
+| application.ingress.hosts[].paths                     | A list of paths for each legacy ingress hosts                                                                                                                                                | `[]`                       | Yes      |
+| application.ingress.hosts[].paths.path                | The path                                                                                                                                                                                     | `/`                        | Yes      |
+| application.ingress.hosts[].paths.backend.serviceName | The service name that the path talks to.                                                                                                                                                     | `application.name`         | Yes      |
+| application.ingress.hosts[].paths.backend.servicePort | The service port that the path talks to.                                                                                                                                                     | `application.port`         | Yes      |
+| application.ingress.tls                               | A set of TLS configuration settings to add to the lagacy ingress.                                                                                                                            | `[]`                       | Yes      |
+| application.ingress.tls.secretName                    | The secret that contains the TLS certs.                                                                                                                                                      |                            | Yes      |
+| application.ingress.tls.hosts                         | The hosts which use the TLS certs contained in the respective secret.                                                                                                                        |                            | Yes      |
 
 ### Cronjob Values
 
 ```yaml
 aruba-uxi:
-  cronjobs:
-    example-cronjob-consumer:
-      ...
-    example-cronjob-producer:
-      ...
+    cronjobs:
+        example-cronjob-consumer: ...
+        example-cronjob-producer: ...
 ```
 
 In this table `cronjob` refers to each cronjob defined under `cronjobs`
 
-| Parameter | Description | Default | Optional |
-|-----|------|---------|--------|
-| cronjob.schedule | The schedule to set for the cronjob to run on | | No |
-| cronjob.suspend | Suspends the cronjob | `false` | Yes |
-| cronjob.image.repository | A specific image that the cronjob should use | `globals.image.repository` | Yes |
-| cronjob.image.tag | The image to use for this specific cronjob | `globals.image.tag` | Yes |
-| cronjob.image.pullPolicy | The image pull policy to use for this cronjob | `globals.image.pullPOlicy` | Yes |
-| cronjob.command | The command that the pod must run. Overrides the docker image command | `""` | Yes |
-| cronjob.args | The arguments that used by the override command | `""` | Yes |
-| cronjob.serviceAccount.create | Creates a service account and adds it to the cronjob. If no name is provided the application name will be used | `false` | Yes |
-| cronjob.serviceAccount.name | The name of the service account to attach to this cronjob| | Yes |
-| cronjob.serviceAccount.annotations | Any annotations to add the service account that is created | | Yes |
-| cronjob.restartPolicy| Whether the cronjob should restart if a job fails | `OnFailure` | Yes |
-| cronjob.env | Basic environment variables specific for this cronjob. Can override the global.env values | `{}` | Yes |
-| cronjob.envFields | Environment variables that pull information from kubernetss object fields for this cronjob. Can override the global.envField values | `{}` | Yes |
-| cronjob.envSealedSecrets | Environment variables from sealed secrets specific to this cronjob. Can override the global.envSealedSecrets values | `{}` | Yes |
-| cronjob.datadog.enabled | Enables datadog metrics. Setting to true will create the necessary environment variables | `false` | Yes |
-| cronjob.datadog.traceEnabled | Enables datadog tracing. | `false` | Yes |
-| cronjob.sentry.enabled | Enables sentry on the cronjob. Setting to true will create the necessary environment variables. You need to add the `.sentry.dsn` value to create the sentry DSN sealed secret | `false` | Yes |
-| cronjob.sentry.dsn | Creates a sealed secret with the sentry DSN from the provided sealed version of the base64 encoded sentry DSN value. The sealed secret name takes the format `<cronjob-name>-sentry-dsn` | | Yes |
-| cronjob.labels | Extra labels to apply to all k8s objects. Includes any extra labels defined in the global object. | `{}` | Yes |
+| Parameter                          | Description                                                                                                                                                                              | Default                    | Optional |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------- |
+| cronjob.schedule                   | The schedule to set for the cronjob to run on                                                                                                                                            |                            | No       |
+| cronjob.suspend                    | Suspends the cronjob                                                                                                                                                                     | `false`                    | Yes      |
+| cronjob.image.repository           | A specific image that the cronjob should use                                                                                                                                             | `globals.image.repository` | Yes      |
+| cronjob.image.tag                  | The image to use for this specific cronjob                                                                                                                                               | `globals.image.tag`        | Yes      |
+| cronjob.image.pullPolicy           | The image pull policy to use for this cronjob                                                                                                                                            | `globals.image.pullPOlicy` | Yes      |
+| cronjob.command                    | The command that the pod must run. Overrides the docker image command                                                                                                                    | `""`                       | Yes      |
+| cronjob.args                       | The arguments that used by the override command                                                                                                                                          | `""`                       | Yes      |
+| cronjob.serviceAccount.create      | Creates a service account and adds it to the cronjob. If no name is provided the application name will be used                                                                           | `false`                    | Yes      |
+| cronjob.serviceAccount.name        | The name of the service account to attach to this cronjob                                                                                                                                |                            | Yes      |
+| cronjob.serviceAccount.annotations | Any annotations to add the service account that is created                                                                                                                               |                            | Yes      |
+| cronjob.restartPolicy              | Whether the cronjob should restart if a job fails                                                                                                                                        | `OnFailure`                | Yes      |
+| cronjob.env                        | Basic environment variables specific for this cronjob. Can override the global.env values                                                                                                | `{}`                       | Yes      |
+| cronjob.envFields                  | Environment variables that pull information from kubernetss object fields for this cronjob. Can override the global.envField values                                                      | `{}`                       | Yes      |
+| cronjob.envSealedSecrets           | Environment variables from sealed secrets specific to this cronjob. Can override the global.envSealedSecrets values                                                                      | `{}`                       | Yes      |
+| cronjob.datadog.enabled            | Enables datadog metrics. Setting to true will create the necessary environment variables                                                                                                 | `false`                    | Yes      |
+| cronjob.datadog.traceEnabled       | Enables datadog tracing.                                                                                                                                                                 | `false`                    | Yes      |
+| cronjob.sentry.enabled             | Enables sentry on the cronjob. Setting to true will create the necessary environment variables. You need to add the `.sentry.dsn` value to create the sentry DSN sealed secret           | `false`                    | Yes      |
+| cronjob.sentry.dsn                 | Creates a sealed secret with the sentry DSN from the provided sealed version of the base64 encoded sentry DSN value. The sealed secret name takes the format `<cronjob-name>-sentry-dsn` |                            | Yes      |
+| cronjob.labels                     | Extra labels to apply to all k8s objects. Includes any extra labels defined in the global object.                                                                                        | `{}`                       | Yes      |
 
 ## Developing Notes
 
@@ -196,9 +189,9 @@ Helm works by using a default `values.yaml` file and overlaying additional value
 
 When using this library the values file is left largely empty except for the following values:
 
-- `aruba-uxi.global.image.repository`
-- `aruba-uxi.global.image.tag`
-- `aruba-uxi.global.repository`
+-   `aruba-uxi.global.image.repository`
+-   `aruba-uxi.global.image.tag`
+-   `aruba-uxi.global.repository`
 
 The `aruba-uxi.global.image.repository` and `aruba-uxi.global.image.tag` values are used as the default image. These can be overridden in other value files but it has to be present in the base `values.yaml` file.
 
@@ -209,11 +202,11 @@ For example, the `values.yaml` file defines the default tag:
 ```yaml
 # values.yaml
 aruba-uxi:
-  global:
-    repoistory: example-service
-    image:
-      repository: example-service
-      tag: 1.0.0
+    global:
+        repoistory: example-service
+        image:
+            repository: example-service
+            tag: 1.0.0
 ```
 
 The staging environment overrides the tag to a development tag
@@ -221,10 +214,10 @@ The staging environment overrides the tag to a development tag
 ```yaml
 # values-staging.yaml
 aruba-uxi:
-  global:
-    image:
-      repository: quay.io/uxi/example-service
-      tag: 1.0.0-dev
+    global:
+        image:
+            repository: quay.io/uxi/example-service
+            tag: 1.0.0-dev
 ```
 
 The production environment uses the default latest tag
@@ -232,13 +225,13 @@ The production environment uses the default latest tag
 ```yaml
 # values-production.yaml
 aruba-uxi:
-  global:
-    image:
-      repository: quay.io/uxi/example-service
-      tag: 1.0.0
+    global:
+        image:
+            repository: quay.io/uxi/example-service
+            tag: 1.0.0
 ```
 
-### _helpers.tpl
+### \_helpers.tpl
 
 The `_helpers.tpl` file is used to assist in creating values used in the chart files.
 

--- a/charts/aruba-uxi/README.md
+++ b/charts/aruba-uxi/README.md
@@ -140,11 +140,12 @@ In this table `application` refers to each application defined under `applicatio
 | application.sentry.dsn | Creates a sealed secret with the sentry DSN from the provided sealed version of the base64 encoded sentry DSN value. The sealed secret name takes the format `<application-name>-sentry-dsn` | | Yes |
 | application.labels | Extra labels to apply to all k8s objects. Includes any extra labels defined in the global object. | `{}` | Yes |
 | application.ingress | Configures the legacy ingress added to an application | `{}` | Yes |
-| application.ingress.useLegacyApiVersion | Toogles the legacy `extensions/v1beta1` kubernetes `apiVersion` for kubernetes clusters that do not support `networking.k8s.io/v1`. | `false` | No |
+| application.ingress.useLegacyApiVersion | Toogles the legacy `extensions/v1beta1` kubernetes `apiVersion` for kubernetes clusters that do not support `networking.k8s.io/v1`. | `false` | Yes |
 | application.ingress.className | Defines the ingressClassName. | `nginx` | Yes |
 | application.ingress.hosts | A list of hosts to add to the legacy ingress. | `[]` | Yes |
 | application.ingress.hosts[].paths | A list of paths for each legacy ingress hosts | `[]` | Yes |
 | application.ingress.hosts[].paths.path | The path | `/` | Yes |
+| application.ingress.hosts[].paths.type | The pathType to use for the respective path. | `ImplementaionSpecific` | Yes |
 | application.ingress.hosts[].paths.backend.serviceName | The service name that the path talks to. | `application.name` | Yes |
 | application.ingress.hosts[].paths.backend.servicePort | The service port that the path talks to. | `application.port` | Yes |
 | application.ingress.tls | A set of TLS configuration settings to add to the lagacy ingress. | `[]` | Yes |

--- a/charts/aruba-uxi/README.md
+++ b/charts/aruba-uxi/README.md
@@ -15,7 +15,7 @@ Typically the `values.yaml` file defines the base values used by helm, and then 
 
 When using this chart library its best to leave the `values.yaml` files empty and define separate values for each environment.
 
-> \***\*NOTE:\*\*** Yes this does go against helm convention but its the best way we can do that does not cause duplicate data. Environment variables proved to be a bit tricky because in the local environment DATABASE_URL for example, could be defined in `.env` then in the staging environment it moves to `.envSealedSecrets`. It proved too hard to remove the duplicate values, so its best not to define any environment variables in the `values.yaml`.
+> ****NOTE:**** Yes this does go against helm convention but its the best way we can do that does not cause duplicate data. Environment variables proved to be a bit tricky because in the local environment DATABASE_URL for example, could be defined in `.env` then in the staging environment it moves to `.envSealedSecrets`. It proved too hard to remove the duplicate values, so its best not to define any environment variables in the `values.yaml`.
 
 It is possible to define some values in the `values.yaml` file. You are welcome to experiment with defining the some values in the `values.yaml` file and overriding them in the environment values file.
 
@@ -23,161 +23,168 @@ It is possible to define some values in the `values.yaml` file. You are welcome 
 
 ```yaml
 aruba-uxi:
-    sealedSecrets: ...
+  sealedSecrets:
+    ...
 ```
 
 Sealed secrets are defined with the `.sealedSecrets` object. A `SealedSecret` kubernetes object is created using the data defined in this map.
 
-| Parameter                     | Description                                                                                                                                                                                                                                                                                   | Default | Optional |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
-| sealedSecrets.imagePullSecret | The sealed version of the base64 encoded `dockerconfigjson` file used to provide access to our image repository                                                                                                                                                                               | ""      | Yes      |
-| sealedSecrets.env             | Sealed secrets used to populate environment variables in the applications and containers. A sealed secret is created for each key in the dictionary. See [values.example.yaml](https://github.com/Aruba-UXI/chart-library/blob/main/examples/aruba-uxi-example/values.example.yaml) for usage | {}      | Yes      |
+| Parameter | Description | Default | Optional |
+|-----|------|---------|---|
+| sealedSecrets.imagePullSecret | The sealed version of the base64 encoded `dockerconfigjson` file used to provide access to our image repository | "" | Yes |
+| sealedSecrets.env | Sealed secrets used to populate environment variables in the applications and containers. A sealed secret is created for each key in the dictionary. See [values.example.yaml](https://github.com/Aruba-UXI/chart-library/blob/main/examples/aruba-uxi-example/values.example.yaml) for usage| {} | Yes |
 
 Follow the instructions in the [Sealed Secrets Wiki](https://github.com/aruba-uxi/knowledge/wiki/Sealed-Secrets) to create a `SealedSecret`.
 
 When naming a sealed secret you need to ensure that the name you use to create the sealed secret and the name you give in the values file is the same.
 
-> \***\*NOTE:\*\*** The `sealedSecrets.imagePullSecret` name should be called `uxi-sealed-image-pull-secret`
+> ****NOTE:**** The `sealedSecrets.imagePullSecret` name should be called `uxi-sealed-image-pull-secret`
 
 Once you have created a `SealedSecret` you will need to copy the encoded value for each key defined.
 
 For example, to create a sealed secret called `database-url` with the key `DATABASE_URL`, you need to follow the instructions in the link above to create a sealed secret with the following values:
 
--   name: `database-url`
--   key `DATABASE_URL`
--   value: The value is the URL taken from wherever the database is hosted
--   namespace: The namespace should be the name of the github repo, unless there are reasons for it to
+- name: `database-url`
+- key `DATABASE_URL`
+- value: The value is the URL taken from wherever the database is hosted
+- namespace: The namespace should be the name of the github repo, unless there are reasons for it to
 
 The output should be a sealed secret with an encoded string for the `DATABASE_URL` value. Copy this value and paste it into the values file in the correct section.
 
 ```yaml
 aruba-uxi:
-    sealedSecrets:
-        env:
-            database-url:
-                DATABASE_URL: sealed_version_of_the_base64_encoded_database_url
+  sealedSecrets:
+    env:
+      database-url:
+        DATABASE_URL: sealed_version_of_the_base64_encoded_database_url
 ```
 
 ### Global Values
 
 ```yaml
 aruba-uxi:
-    global: ...
+  global:
+    ...
 ```
 
 Global values used by all kubernetes objects. The `Can Override` column in the table identifies which values can be overridden by the applications or cronjobs.
 
-| Parameter                    | Description                                                                                                                                                                                        | Default          | Optional | Can Override |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- | ------------ |
-| global.repository            | The github repository that these charts are kept in                                                                                                                                                |                  | No       | No           |
-| global.environment           | The environment that the service is being deployed to. Values are converted to lowercase when used. Validation is also done on the values. Valid environments are (`DEV`, `STAGING`, `PRODUCTION`) |                  | No       | No           |
-| global.image.repository      | The image repository to use for images.                                                                                                                                                            |                  | No       | Yes          |
-| global.image.tag             | The image tag to use.                                                                                                                                                                              |                  | No       | Yes          |
-| global.image.imagePullPolicy | The image pull policy to use.                                                                                                                                                                      | `"IfNotPresent"` | Yes      | Yes          |
-| global.env                   | Basic environment variables. Precedence is given to the overridden values                                                                                                                          | `{}`             | Yes      | Yes          |
-| global.envFields             | Environment variables that pull information from kubernetss object fields. Precedence is given to the overridden values                                                                            | `{}`             | Yes      | Yes          |
-| global.envSealedSecrets      | Environment variables from sealed secrets. Precedence is given to the overridden values.                                                                                                           | `{}`             | Yes      | Yes          |
-| global.labels                | Extra labels to apply to all k8s objects (excluding `sealedSecrets.imagePullSecret`).                                                                                                              | `{}`             | Yes      | Yes          |
+| Parameter | Description | Default | Optional | Can Override |
+|-----|------|---------|---|---|
+| global.repository | The github repository that these charts are kept in | | No | No |
+| global.environment | The environment that the service is being deployed to. Values are converted to lowercase when used. Validation is also done on the values. Valid environments are (`DEV`, `STAGING`, `PRODUCTION`) | | No | No |
+| global.image.repository | The image repository to use for images. | | No | Yes |
+| global.image.tag | The image tag to use. | | No | Yes |
+| global.image.imagePullPolicy | The image pull policy to use. | `"IfNotPresent"` | Yes | Yes |
+| global.env | Basic environment variables. Precedence is given to the overridden values | `{}` | Yes | Yes |
+| global.envFields | Environment variables that pull information from kubernetss object fields. Precedence is given to the overridden values | `{}` | Yes |  Yes |
+| global.envSealedSecrets | Environment variables from sealed secrets. Precedence is given to the overridden values. | `{}` | Yes | Yes |
+| global.labels | Extra labels to apply to all k8s objects (excluding `sealedSecrets.imagePullSecret`). | `{}` | Yes | Yes |
 
-> \***\*NOTE:\*\*** The `.global.image.tag` is required in the `values.yaml` file but is option in all overlays.
+> ****NOTE:**** The `.global.image.tag` is required in the `values.yaml` file but is option in all overlays.
 
 ### Application Values
 
 ```yaml
 aruba-uxi:
-    applications:
-        example-webapp: ...
-        example-worker: ...
+  applications:
+    example-webapp:
+      ...
+    example-worker:
+      ...
 ```
 
 In this table `application` refers to each application defined under `applications`
 
-| Parameter                                             | Description                                                                                                                                                                                  | Default                    | Optional |
-| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------- |
-| application.role                                      | The role that this application will serve. Validation is done to make sure the correct role is provided. Valid roles are (`webapp`, `worker`)                                                |                            | No       |
-| application.revisionHistoryLimit                      | The number of old ReplicaSets to be retained                                                                                                                                                 | `3`                        | Yes      |
-| application.replicaCount                              | The number of pod replicas to create                                                                                                                                                         | `1`                        | Yes      |
-| application.image.repository                          | A specific image that the application should use                                                                                                                                             | `globals.image.repository` | Yes      |
-| application.image.tag                                 | The image to use for this specific application                                                                                                                                               | `globals.image.tag`        | Yes      |
-| application.image.pullPolicy                          | The image pull policy to use for this application                                                                                                                                            | `globals.image.pullPOlicy` | Yes      |
-| application.serviceAccount.create                     | Creates a service account and adds it to the application. If no name is provided the application name will be used                                                                           | `false`                    | Yes      |
-| application.serviceAccount.name                       | The name of the service account to attach to this application                                                                                                                                |                            | Yes      |
-| application.serviceAccount.annotations                | Any annotations to add the service account that is created                                                                                                                                   |                            | Yes      |
-| application.command                                   | The command that the pod must run. Overrides the docker image command                                                                                                                        | `""`                       | Yes      |
-| application.args                                      | The arguments that used by the override command                                                                                                                                              | `""`                       | Yes      |
-| application.port                                      | The port that must be exposed on the pod. Also used when adding a service to the webapp. Can be excluded when defining a worker                                                              |                            | No       |
-| application.service                                   | Configures the service created for webapps                                                                                                                                                   | `ClusterIP`                | Yes      |
-| application.service.type                              | Configures the service type that is created for webapps                                                                                                                                      | `ClusterIP`                | Yes      |
-| application.service.port                              | Configures the service port to expose                                                                                                                                                        | `80`                       | Yes      |
-| application.livenessProbe.path                        | The API path to query for liveness tests                                                                                                                                                     | `/livez`                   | Yes      |
-| application.readinessProbe.path                       | The API path to query for readiness tests                                                                                                                                                    | `/readyz`                  | Yes      |
-| application.livenessProbe.command                     | The command to use to test liveness (as opposed to livenessProbe.path)                                                                                                                       |                            | Yes      |
-| application.readinessProbe.command                    | The command to use to test readiness (as opposed to readinessProbe.path)                                                                                                                     |                            | Yes      |
-| application.resources                                 | Resource limits and requests to set on the pod. See [link](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more details on the structure                 | `{}`                       | Yes      |
-| application.nodeSelector                              | Node selector specifications to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for more details on the structure          | `{}`                       | Yes      |
-| application.tolerations                               | Tolerations to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more details on the structure                                   | `{}`                       | Yes      |
-| application.affinity                                  | Affinity to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for more details on the structure                | `{}`                       | Yes      |
-| application.securityContext                           | Sets the security contextfor the pods. See [link](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for more details on the structure                              | `{}`                       | Yes      |
-| application.configMap                                 | A config map to create and apply to the application                                                                                                                                          |                            | Yes      |
-| application.configMap.annotations                     | Annotations to add to the config map                                                                                                                                                         | `{}`                       | Yes      |
-| application.configMap.readOnly                        | Whether the configmap is mapped as readonly or not                                                                                                                                           | `true`                     | Yes      |
-| application.configMap.path                            | The path to map the config map to in the pod                                                                                                                                                 | `{}`                       | Yes      |
-| application.configMap.data                            | The data to add to the config map                                                                                                                                                            | `{}`                       | Yes      |
-| application.secretMount                               | A secret mount to add secrets as a file to the pod                                                                                                                                           |                            | Yes      |
-| application.secretMount.name                          | The name of the secret volume to be mounted                                                                                                                                                  |                            | Yes      |
-| application.secretMount.path                          | The path to mount the secret on in the pod                                                                                                                                                   | `{}`                       | Yes      |
-| application.secretMount.readOnly                      | Whether the secret is mounted as readonly file or not                                                                                                                                        | `true`                     | Yes      |
-| application.env                                       | Basic environment variables specific for this application. Can override the global.env values                                                                                                | `{}`                       | Yes      |
-| application.envFields                                 | Environment variables that pull information from kubernetss object fields for this application. Can override the global.envField values                                                      | `{}`                       | Yes      |
-| application.envSealedSecrets                          | Environment variables from sealed secrets specific to this application. Can override the global.envSealedSecrets values                                                                      | `{}`                       | Yes      |
-| application.datadog.enabled                           | Enables datadog metrics. Setting to true will create the necessary environment variables                                                                                                     | `false`                    | Yes      |
-| application.datadog.traceEnabled                      | Enables datadog tracing.                                                                                                                                                                     | `false`                    | Yes      |
-| application.sentry.enabled                            | Enables sentry on the application. Setting to true will create the necessary environment variables. You need to add the `.sentry.dsn` value to create the sentry DSN sealed secret           | `false`                    | Yes      |
-| application.sentry.dsn                                | Creates a sealed secret with the sentry DSN from the provided sealed version of the base64 encoded sentry DSN value. The sealed secret name takes the format `<application-name>-sentry-dsn` |                            | Yes      |
-| application.labels                                    | Extra labels to apply to all k8s objects. Includes any extra labels defined in the global object.                                                                                            | `{}`                       | Yes      |
-| application.ingress                                   | Configures the legacy ingress added to an application                                                                                                                                        | `{}`                       | Yes      |
-| application.ingress.className                         | Defines the ingressClassName.                                                                                                                                                                | `nginx`                    | Yes      |
-| application.ingress.hosts                             | A list of hosts to add to the legacy ingress.                                                                                                                                                | `[]`                       | Yes      |
-| application.ingress.hosts[].paths                     | A list of paths for each legacy ingress hosts                                                                                                                                                | `[]`                       | Yes      |
-| application.ingress.hosts[].paths.path                | The path                                                                                                                                                                                     | `/`                        | Yes      |
-| application.ingress.hosts[].paths.backend.serviceName | The service name that the path talks to.                                                                                                                                                     | `application.name`         | Yes      |
-| application.ingress.hosts[].paths.backend.servicePort | The service port that the path talks to.                                                                                                                                                     | `application.port`         | Yes      |
-| application.ingress.tls                               | A set of TLS configuration settings to add to the lagacy ingress.                                                                                                                            | `[]`                       | Yes      |
-| application.ingress.tls.secretName                    | The secret that contains the TLS certs.                                                                                                                                                      |                            | Yes      |
-| application.ingress.tls.hosts                         | The hosts which use the TLS certs contained in the respective secret.                                                                                                                        |                            | Yes      |
+| Parameter | Description | Default | Optional |
+|-----|------|---------|--------|
+| application.role | The role that this application will serve. Validation is done to make sure the correct role is provided. Valid roles are (`webapp`, `worker`) | | No |
+| application.revisionHistoryLimit | The number of old ReplicaSets to be retained | `3` | Yes |
+| application.replicaCount | The number of pod replicas to create | `1` | Yes |
+| application.image.repository | A specific image that the application should use | `globals.image.repository` | Yes |
+| application.image.tag | The image to use for this specific application | `globals.image.tag` | Yes |
+| application.image.pullPolicy | The image pull policy to use for this application | `globals.image.pullPOlicy` | Yes |
+| application.serviceAccount.create | Creates a service account and adds it to the application. If no name is provided the application name will be used | `false` | Yes |
+| application.serviceAccount.name | The name of the service account to attach to this application| | Yes |
+| application.serviceAccount.annotations | Any annotations to add the service account that is created | | Yes |
+| application.command | The command that the pod must run. Overrides the docker image command | `""` | Yes |
+| application.args | The arguments that used by the override command | `""` | Yes |
+| application.port | The port that must be exposed on the pod. Also used when adding a service to the webapp. Can be excluded when defining a worker | | No |
+| application.service | Configures the service created for webapps | `ClusterIP` | Yes |
+| application.service.type | Configures the service type that is created for webapps | `ClusterIP` | Yes |
+| application.service.port | Configures the service port to expose | `80` | Yes |
+| application.livenessProbe.path | The API path to query for liveness tests | `/livez` | Yes |
+| application.readinessProbe.path | The API path to query for readiness tests | `/readyz` | Yes |
+| application.livenessProbe.command | The command to use to test liveness (as opposed to livenessProbe.path) | | Yes |
+| application.readinessProbe.command | The command to use to test readiness (as opposed to readinessProbe.path)| | Yes |
+| application.resources | Resource limits and requests to set on the pod. See [link](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more details on the structure | `{}` | Yes |
+| application.nodeSelector | Node selector specifications to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for more details on the structure | `{}` | Yes |
+| application.tolerations | Tolerations to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more details on the structure | `{}` | Yes |
+| application.affinity | Affinity to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for more details on the structure | `{}` | Yes |
+| application.securityContext | Sets the security contextfor the pods. See [link](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for more details on the structure | `{}` | Yes |
+| application.configMap | A config map to create and apply to the application | | Yes |
+| application.configMap.annotations | Annotations to add to the config map | `{}` | Yes |
+| application.configMap.readOnly | Whether the configmap is mapped as readonly or not | `true` | Yes |
+| application.configMap.path | The path to map the config map to in the pod | `{}` | Yes |
+| application.configMap.data | The data to add to the config map | `{}` | Yes |
+| application.secretMount | A secret mount to add secrets as a file to the pod | | Yes |
+| application.secretMount.name | The name of the secret volume to be mounted | | Yes |
+| application.secretMount.path | The path to mount the secret on in the pod | `{}` | Yes |
+| application.secretMount.readOnly | Whether the secret is mounted as readonly file or not | `true` | Yes |
+| application.env | Basic environment variables specific for this application. Can override the global.env values | `{}` | Yes |
+| application.envFields | Environment variables that pull information from kubernetss object fields for this application. Can override the global.envField values | `{}` | Yes |
+| application.envSealedSecrets | Environment variables from sealed secrets specific to this application. Can override the global.envSealedSecrets values | `{}` | Yes |
+| application.datadog.enabled | Enables datadog metrics. Setting to true will create the necessary environment variables | `false` | Yes |
+| application.datadog.traceEnabled | Enables datadog tracing. | `false` | Yes |
+| application.sentry.enabled | Enables sentry on the application. Setting to true will create the necessary environment variables. You need to add the `.sentry.dsn` value to create the sentry DSN sealed secret | `false` | Yes |
+| application.sentry.dsn | Creates a sealed secret with the sentry DSN from the provided sealed version of the base64 encoded sentry DSN value. The sealed secret name takes the format `<application-name>-sentry-dsn` | | Yes |
+| application.labels | Extra labels to apply to all k8s objects. Includes any extra labels defined in the global object. | `{}` | Yes |
+| application.ingress | Configures the legacy ingress added to an application | `{}` | Yes |
+| application.ingress.useLegacyApiVersion | Toogles the legacy `extensions/v1beta1` kubernetes `apiVersion` for kubernetes clusters that do not support `networking.k8s.io/v1`. | `false` | No |
+| application.ingress.className | Defines the ingressClassName. | `nginx` | Yes |
+| application.ingress.hosts | A list of hosts to add to the legacy ingress. | `[]` | Yes |
+| application.ingress.hosts[].paths | A list of paths for each legacy ingress hosts | `[]` | Yes |
+| application.ingress.hosts[].paths.path | The path | `/` | Yes |
+| application.ingress.hosts[].paths.backend.serviceName | The service name that the path talks to. | `application.name` | Yes |
+| application.ingress.hosts[].paths.backend.servicePort | The service port that the path talks to. | `application.port` | Yes |
+| application.ingress.tls | A set of TLS configuration settings to add to the lagacy ingress. | `[]` | Yes |
+| application.ingress.tls.secretName | The secret that contains the TLS certs. | | Yes |
+| application.ingress.tls.hosts | The hosts which use the TLS certs contained in the respective secret. | | Yes |
 
 ### Cronjob Values
 
 ```yaml
 aruba-uxi:
-    cronjobs:
-        example-cronjob-consumer: ...
-        example-cronjob-producer: ...
+  cronjobs:
+    example-cronjob-consumer:
+      ...
+    example-cronjob-producer:
+      ...
 ```
 
 In this table `cronjob` refers to each cronjob defined under `cronjobs`
 
-| Parameter                          | Description                                                                                                                                                                              | Default                    | Optional |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------- |
-| cronjob.schedule                   | The schedule to set for the cronjob to run on                                                                                                                                            |                            | No       |
-| cronjob.suspend                    | Suspends the cronjob                                                                                                                                                                     | `false`                    | Yes      |
-| cronjob.image.repository           | A specific image that the cronjob should use                                                                                                                                             | `globals.image.repository` | Yes      |
-| cronjob.image.tag                  | The image to use for this specific cronjob                                                                                                                                               | `globals.image.tag`        | Yes      |
-| cronjob.image.pullPolicy           | The image pull policy to use for this cronjob                                                                                                                                            | `globals.image.pullPOlicy` | Yes      |
-| cronjob.command                    | The command that the pod must run. Overrides the docker image command                                                                                                                    | `""`                       | Yes      |
-| cronjob.args                       | The arguments that used by the override command                                                                                                                                          | `""`                       | Yes      |
-| cronjob.serviceAccount.create      | Creates a service account and adds it to the cronjob. If no name is provided the application name will be used                                                                           | `false`                    | Yes      |
-| cronjob.serviceAccount.name        | The name of the service account to attach to this cronjob                                                                                                                                |                            | Yes      |
-| cronjob.serviceAccount.annotations | Any annotations to add the service account that is created                                                                                                                               |                            | Yes      |
-| cronjob.restartPolicy              | Whether the cronjob should restart if a job fails                                                                                                                                        | `OnFailure`                | Yes      |
-| cronjob.env                        | Basic environment variables specific for this cronjob. Can override the global.env values                                                                                                | `{}`                       | Yes      |
-| cronjob.envFields                  | Environment variables that pull information from kubernetss object fields for this cronjob. Can override the global.envField values                                                      | `{}`                       | Yes      |
-| cronjob.envSealedSecrets           | Environment variables from sealed secrets specific to this cronjob. Can override the global.envSealedSecrets values                                                                      | `{}`                       | Yes      |
-| cronjob.datadog.enabled            | Enables datadog metrics. Setting to true will create the necessary environment variables                                                                                                 | `false`                    | Yes      |
-| cronjob.datadog.traceEnabled       | Enables datadog tracing.                                                                                                                                                                 | `false`                    | Yes      |
-| cronjob.sentry.enabled             | Enables sentry on the cronjob. Setting to true will create the necessary environment variables. You need to add the `.sentry.dsn` value to create the sentry DSN sealed secret           | `false`                    | Yes      |
-| cronjob.sentry.dsn                 | Creates a sealed secret with the sentry DSN from the provided sealed version of the base64 encoded sentry DSN value. The sealed secret name takes the format `<cronjob-name>-sentry-dsn` |                            | Yes      |
-| cronjob.labels                     | Extra labels to apply to all k8s objects. Includes any extra labels defined in the global object.                                                                                        | `{}`                       | Yes      |
+| Parameter | Description | Default | Optional |
+|-----|------|---------|--------|
+| cronjob.schedule | The schedule to set for the cronjob to run on | | No |
+| cronjob.suspend | Suspends the cronjob | `false` | Yes |
+| cronjob.image.repository | A specific image that the cronjob should use | `globals.image.repository` | Yes |
+| cronjob.image.tag | The image to use for this specific cronjob | `globals.image.tag` | Yes |
+| cronjob.image.pullPolicy | The image pull policy to use for this cronjob | `globals.image.pullPOlicy` | Yes |
+| cronjob.command | The command that the pod must run. Overrides the docker image command | `""` | Yes |
+| cronjob.args | The arguments that used by the override command | `""` | Yes |
+| cronjob.serviceAccount.create | Creates a service account and adds it to the cronjob. If no name is provided the application name will be used | `false` | Yes |
+| cronjob.serviceAccount.name | The name of the service account to attach to this cronjob| | Yes |
+| cronjob.serviceAccount.annotations | Any annotations to add the service account that is created | | Yes |
+| cronjob.restartPolicy| Whether the cronjob should restart if a job fails | `OnFailure` | Yes |
+| cronjob.env | Basic environment variables specific for this cronjob. Can override the global.env values | `{}` | Yes |
+| cronjob.envFields | Environment variables that pull information from kubernetss object fields for this cronjob. Can override the global.envField values | `{}` | Yes |
+| cronjob.envSealedSecrets | Environment variables from sealed secrets specific to this cronjob. Can override the global.envSealedSecrets values | `{}` | Yes |
+| cronjob.datadog.enabled | Enables datadog metrics. Setting to true will create the necessary environment variables | `false` | Yes |
+| cronjob.datadog.traceEnabled | Enables datadog tracing. | `false` | Yes |
+| cronjob.sentry.enabled | Enables sentry on the cronjob. Setting to true will create the necessary environment variables. You need to add the `.sentry.dsn` value to create the sentry DSN sealed secret | `false` | Yes |
+| cronjob.sentry.dsn | Creates a sealed secret with the sentry DSN from the provided sealed version of the base64 encoded sentry DSN value. The sealed secret name takes the format `<cronjob-name>-sentry-dsn` | | Yes |
+| cronjob.labels | Extra labels to apply to all k8s objects. Includes any extra labels defined in the global object. | `{}` | Yes |
 
 ## Developing Notes
 
@@ -189,9 +196,9 @@ Helm works by using a default `values.yaml` file and overlaying additional value
 
 When using this library the values file is left largely empty except for the following values:
 
--   `aruba-uxi.global.image.repository`
--   `aruba-uxi.global.image.tag`
--   `aruba-uxi.global.repository`
+- `aruba-uxi.global.image.repository`
+- `aruba-uxi.global.image.tag`
+- `aruba-uxi.global.repository`
 
 The `aruba-uxi.global.image.repository` and `aruba-uxi.global.image.tag` values are used as the default image. These can be overridden in other value files but it has to be present in the base `values.yaml` file.
 
@@ -202,11 +209,11 @@ For example, the `values.yaml` file defines the default tag:
 ```yaml
 # values.yaml
 aruba-uxi:
-    global:
-        repoistory: example-service
-        image:
-            repository: example-service
-            tag: 1.0.0
+  global:
+    repoistory: example-service
+    image:
+      repository: example-service
+      tag: 1.0.0
 ```
 
 The staging environment overrides the tag to a development tag
@@ -214,10 +221,10 @@ The staging environment overrides the tag to a development tag
 ```yaml
 # values-staging.yaml
 aruba-uxi:
-    global:
-        image:
-            repository: quay.io/uxi/example-service
-            tag: 1.0.0-dev
+  global:
+    image:
+      repository: quay.io/uxi/example-service
+      tag: 1.0.0-dev
 ```
 
 The production environment uses the default latest tag
@@ -225,13 +232,13 @@ The production environment uses the default latest tag
 ```yaml
 # values-production.yaml
 aruba-uxi:
-    global:
-        image:
-            repository: quay.io/uxi/example-service
-            tag: 1.0.0
+  global:
+    image:
+      repository: quay.io/uxi/example-service
+      tag: 1.0.0
 ```
 
-### \_helpers.tpl
+### _helpers.tpl
 
 The `_helpers.tpl` file is used to assist in creating values used in the chart files.
 

--- a/charts/aruba-uxi/templates/application-ingress.yaml
+++ b/charts/aruba-uxi/templates/application-ingress.yaml
@@ -2,8 +2,10 @@
 {{- $ingress := default dict $data.ingress }}
 {{- $svcPort := $data.port }}
 {{- $service := default dict $data.service }}
+{{- $useLegacyApiVersion := default false $ingress.useLegacyApiVersion }}
 {{- $additionalLabels := deepCopy (default dict $.Values.global.labels) | mustMerge (default dict $data.labels) }}
 {{- if $ingress -}}
+{{- if $useLegacyApiVersion }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -42,5 +44,46 @@ spec:
           {{- end }}
       {{- end }}
   {{- end }}
+{{- else }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "aruba-uxi.labels" (dict "context" $ "name" $name "additionalLabels" $additionalLabels) | nindent 4 }}
+spec:
+  ingressClassName: {{ $ingress.className }}
+  {{- if $ingress.tls }}
+  tls:
+  {{- range $ingress.tls }}
+  - hosts:
+      {{- range .hosts }}
+      - {{ . | quote }}
+      {{- end }}
+    secretName: {{ .secretName }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- range $ingress.hosts }}
+  - host: {{ .host }}
+    http:
+      paths:
+      {{- range $path := .paths }}
+      - path: {{ $path.path }}
+        backend:
+          {{- if $path.backend }}
+          service:
+            name: {{ default $name $path.backend.serviceName }}
+            port:
+              number: {{ default 80 $path.backend.servicePort }}
+          {{- else }}
+          service:
+            name: {{ $name }}
+            port:
+              number: {{ default 80 $service.port }}
+          {{- end }}
+      {{- end }}
+  {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/aruba-uxi/templates/application-ingress.yaml
+++ b/charts/aruba-uxi/templates/application-ingress.yaml
@@ -3,7 +3,7 @@
 {{- $svcPort := $data.port }}
 {{- $service := default dict $data.service }}
 {{- $additionalLabels := deepCopy (default dict $.Values.global.labels) | mustMerge (default dict $data.labels) }}
-{{- if $ingress.enabled -}}
+{{- if $ingress -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/charts/aruba-uxi/templates/application-ingress.yaml
+++ b/charts/aruba-uxi/templates/application-ingress.yaml
@@ -70,6 +70,7 @@ spec:
       paths:
       {{- range $path := .paths }}
       - path: {{ $path.path }}
+        pathType: {{ default "ImplementationSpecific" $path.type }}
         backend:
           {{- if $path.backend }}
           service:

--- a/charts/aruba-uxi/values.example.yaml
+++ b/charts/aruba-uxi/values.example.yaml
@@ -225,6 +225,7 @@ aruba-uxi:
           - host: example-service.local
             paths:
               - path: /
+                type: Prefix
                 backend:
                   serviceName: example-service
                   servicePort: 8000

--- a/charts/aruba-uxi/values.example.yaml
+++ b/charts/aruba-uxi/values.example.yaml
@@ -83,7 +83,8 @@ aruba-uxi:
       ## Configures the image and image pull policy (Optional)
       ## Default: uses .global.image
       ##
-      image: {}
+      image:
+        {}
         # repository: nginx
         # pullPolicy: IfNotPresent
         # tag: ""
@@ -105,7 +106,8 @@ aruba-uxi:
       ## Configures the service created (Optional)
       ## Default: ClusterIP on port 80
       ##
-      service: {}
+      service:
+        {}
         # type: ClusterIP
         # port: 80
       ## Enables the liveness probe on the specified path (Optional)
@@ -121,7 +123,8 @@ aruba-uxi:
       ## Configure the pod resources (Optional)
       ## Default: lets kubernetes set the resources
       ##
-      resources: {}
+      resources:
+        {}
         # limits:
         #   cpu: 100m
         #   memory: 256Mi
@@ -143,7 +146,8 @@ aruba-uxi:
       ## Configures the security context for the pods (Optional)
       ## Default: None
       ##
-      securityContext: {}
+      securityContext:
+        {}
         # runAsUser: 1000
         # runAsGroup: 3000
         # fsGroup: 2000
@@ -215,15 +219,14 @@ aruba-uxi:
       ## Configures a legacy ingress on the application (Optional)
       ## Default: None
       ingress:
-        enabled: false
         className: nginx
         hosts:
-        - host: example-service.local
-          paths:
-          - path: /
-            backend:
-              serviceName: example-service
-              servicePort: 8000
+          - host: example-service.local
+            paths:
+              - path: /
+                backend:
+                  serviceName: example-service
+                  servicePort: 8000
         tls: []
         # - secretName: chart-example-tls
         #   hosts:
@@ -233,9 +236,9 @@ aruba-uxi:
       ## Default: None
       ###
       secretMount:
-      - name: secret-name
-        readOnly: true
-        path: /path/to/mount/folder
+        - name: secret-name
+          readOnly: true
+          path: /path/to/mount/folder
     example-worker:
       ## The application role
       ## The difference between a webapp and worker is the worker does not have ports exposed.
@@ -254,7 +257,8 @@ aruba-uxi:
       ## Configures the image and image pull policy (Optional)
       ## Default: uses .global.image
       ##
-      image: {}
+      image:
+        {}
         # repository: nginx
         # pullPolicy: IfNotPresent
         # tag: ""
@@ -279,7 +283,8 @@ aruba-uxi:
       ## Configures the service created (Optional)
       ## Default: ClusterIP on port 80
       ##
-      service: {}
+      service:
+        {}
         # type: ClusterIP
         # port: 80
       ##
@@ -294,7 +299,8 @@ aruba-uxi:
       ## Configure the pod resources (Optional)
       ## Default: lets kubernetes set the resources
       ##
-      resources: {}
+      resources:
+        {}
         # limits:
         #   cpu: 100m
         #   memory: 256Mi
@@ -316,11 +322,12 @@ aruba-uxi:
       ## Configures the security context for the pods (Optional)
       ## Default: None
       ##
-      securityContext: {}
+      securityContext:
+        {}
         # runAsUser: 1000
         # runAsGroup: 3000
         # fsGroup: 2000
-       ## Adds a config map to the application (Optional)
+        ## Adds a config map to the application (Optional)
       ## Default: None
       ###
       configMap:

--- a/charts/aruba-uxi/values.example.yaml
+++ b/charts/aruba-uxi/values.example.yaml
@@ -219,6 +219,7 @@ aruba-uxi:
       ## Configures a legacy ingress on the application (Optional)
       ## Default: None
       ingress:
+        useLegacyApiVersion: false
         className: nginx
         hosts:
           - host: example-service.local

--- a/examples/aruba-uxi-example/Chart.yaml
+++ b/examples/aruba-uxi-example/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Aruba UX
 type: application
 version: 1.2.6
 dependencies:
-- name: aruba-uxi
-  version: "*"
-  repository: file://../../charts/aruba-uxi
+  - name: aruba-uxi
+    version: "*"
+    repository: file://../../charts/aruba-uxi

--- a/examples/aruba-uxi-example/output-local.yaml
+++ b/examples/aruba-uxi-example/output-local.yaml
@@ -52,45 +52,45 @@ spec:
         namespace: default
     spec:
       containers:
-      - name: webapp
-        image: aruba-uxi-example:latest
-        imagePullPolicy: Never
-        env:
-        - name: ENVIRONMENT
-          value: "dev"
-        - name: DD_ENABLED
-          value: "false"        
-        - name: DATABASE_URL
-          value: "postgresql://username:password@db:5432/aruba-uxi-example"
-        - name: DEBUG
-          value: "true"        
-        - name: HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP        
-        ports:
-        - name: http
-          containerPort: 8000
-          protocol: TCP
-        readinessProbe:
-          exec:
-            command: "/readyz"
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 1
-          successThreshold: 1
-          failureThreshold: 3
-        livenessProbe:
-          httpGet:
-            httpHeaders:
-            - name: Host
-              value: livenessProbe
-            - name: Content-Type
-              value: application/json
-            path: /livez
-            port: 8000
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 1
-          successThreshold: 1
-          failureThreshold: 3
+        - name: webapp
+          image: aruba-uxi-example:latest
+          imagePullPolicy: Never
+          env:
+            - name: ENVIRONMENT
+              value: "dev"
+            - name: DD_ENABLED
+              value: "false"
+            - name: DATABASE_URL
+              value: "postgresql://username:password@db:5432/aruba-uxi-example"
+            - name: DEBUG
+              value: "true"
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command: "/readyz"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              httpHeaders:
+                - name: Host
+                  value: livenessProbe
+                - name: Content-Type
+                  value: application/json
+              path: /livez
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3

--- a/examples/aruba-uxi-example/output-local.yaml
+++ b/examples/aruba-uxi-example/output-local.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -46,51 +46,51 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-3.0.3
+        helm.sh/chart: aruba-uxi-3.1.0
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
     spec:
       containers:
-        - name: webapp
-          image: aruba-uxi-example:latest
-          imagePullPolicy: Never
-          env:
-            - name: ENVIRONMENT
-              value: "dev"
-            - name: DD_ENABLED
-              value: "false"
-            - name: DATABASE_URL
-              value: "postgresql://username:password@db:5432/aruba-uxi-example"
-            - name: DEBUG
-              value: "true"
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-          ports:
-            - name: http
-              containerPort: 8000
-              protocol: TCP
-          readinessProbe:
-            exec:
-              command: "/readyz"
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 1
-            successThreshold: 1
-            failureThreshold: 3
-          livenessProbe:
-            httpGet:
-              httpHeaders:
-                - name: Host
-                  value: livenessProbe
-                - name: Content-Type
-                  value: application/json
-              path: /livez
-              port: 8000
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 1
-            successThreshold: 1
-            failureThreshold: 3
+      - name: webapp
+        image: aruba-uxi-example:latest
+        imagePullPolicy: Never
+        env:
+        - name: ENVIRONMENT
+          value: "dev"
+        - name: DD_ENABLED
+          value: "false"        
+        - name: DATABASE_URL
+          value: "postgresql://username:password@db:5432/aruba-uxi-example"
+        - name: DEBUG
+          value: "true"        
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP        
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command: "/readyz"
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: Host
+              value: livenessProbe
+            - name: Content-Type
+              value: application/json
+            path: /livez
+            port: 8000
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3

--- a/examples/aruba-uxi-example/output-production.yaml
+++ b/examples/aruba-uxi-example/output-production.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
-    example-service-staging: example-service-staging
+    example-service-production: example-service-production
     global-label: global-label
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/cronjob-serviceaccount.yaml
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
-    example-service-staging: example-service-staging
+    example-service-production: example-service-production
     global-label: global-label
 data:
     config.json: |
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
-    example-service-staging: example-service-staging
+    example-service-production: example-service-production
     global-label: global-label
 spec:
   type: ClusterIP
@@ -89,10 +89,10 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
-    example-service-staging: example-service-staging
+    example-service-production: example-service-production
     global-label: global-label
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: example-service
@@ -107,7 +107,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
-        example-service-staging: example-service-staging
+        example-service-production: example-service-production
         global-label: global-label
     spec:
       imagePullSecrets:
@@ -116,14 +116,14 @@ spec:
       containers:
       - name: webapp
         image: quay.io/uxi/nginx:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         env:
         - name: ENVIRONMENT
-          value: "staging"
+          value: "production"
         - name: DD_ENABLED
           value: "true"
         - name: DD_ENV
-          value: "staging"
+          value: "production"
         - name: DD_SERVICE
           value: "example-service"
         - name: DD_TRACE_ENABLED
@@ -137,7 +137,7 @@ spec:
             fieldRef:
               fieldPath: metadata.uid
         - name: SENTRY_ENVIRONMENT
-          value: "staging"
+          value: "production"
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
@@ -249,15 +249,15 @@ spec:
       containers:
       - name: worker
         image: quay.io/uxi/busybox:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: ["/bin/sh","-c","while true; do sleep 3600; date; done;"]
         env:
         - name: ENVIRONMENT
-          value: "staging"
+          value: "production"
         - name: DD_ENABLED
           value: "false"
         - name: SENTRY_ENVIRONMENT
-          value: "staging"
+          value: "production"
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
@@ -282,11 +282,11 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
-    example-cronjob-consumer-staging: example-cronjob-consumer-staging
+    example-cronjob-consumer-production: example-cronjob-consumer-production
     global-label: global-label
 spec:
   schedule: "0 * * * *"
-  suspend: true
+  suspend: false
   jobTemplate:
     spec:
       template:
@@ -296,10 +296,10 @@ spec:
           containers:
           - name: example-cronjob-consumer
             image: quay.io/uxi/busybox:latest
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent
             env:
             - name: ENVIRONMENT
-              value: "staging"
+              value: "production"
             - name: DD_ENABLED
               value: "false"            
             - name: DEBUG
@@ -332,7 +332,7 @@ metadata:
     global-label: global-label
 spec:
   schedule: "0 * * * *"
-  suspend: true
+  suspend: false
   jobTemplate:
     spec:
       template:
@@ -343,10 +343,10 @@ spec:
           containers:
           - name: example-cronjob-producer
             image: quay.io/uxi/busybox:latest
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent
             env:
             - name: ENVIRONMENT
-              value: "staging"
+              value: "production"
             - name: DD_ENABLED
               value: "false"            
             - name: DEBUG
@@ -359,7 +359,7 @@ spec:
           restartPolicy: OnFailure
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-ingress.yaml
-apiVersion: networking.k8s.io/v1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: example-service
@@ -370,21 +370,19 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
-    example-service-staging: example-service-staging
+    example-service-production: example-service-production
     global-label: global-label
+  annotations:
+    kubernetes.io/ingress.class: internal-gateway
 spec:
-  ingressClassName: internal-gateway
   rules:
-  - host: example-service.staging.capedev.io
+  - host: example-service.capenetworks.io
     http:
       paths:
       - path: /
-        pathType: Prefix
         backend:
-          service:
-            name: example-service
-            port:
-              number: 80
+          serviceName: example-service
+          servicePort: 80
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-sentry-dsn.yaml
 apiVersion: bitnami.com/v1alpha1
@@ -398,7 +396,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
-    example-service-staging: example-service-staging
+    example-service-production: example-service-production
     global-label: global-label
 spec:
   encryptedData:

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -36,21 +36,21 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
     example-service-staging: example-service-staging
     global-label: global-label
 data:
-  config.json: |
-    {
-      foo: bar
-      bing: bang
-      server: {
-        host: hostname
+    config.json: |
+      {
+        foo: bar
+        bing: bang
+        server: {
+          host: hostname
+        }
       }
-    }
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-service.yaml
 apiVersion: v1
@@ -60,7 +60,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -85,7 +85,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -103,7 +103,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-3.0.3
+        helm.sh/chart: aruba-uxi-3.1.0
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -111,107 +111,107 @@ spec:
         global-label: global-label
     spec:
       imagePullSecrets:
-        - name: aruba-uxi-example-image-pull-secret
+      - name: aruba-uxi-example-image-pull-secret
       serviceAccountName: example-service
       containers:
-        - name: webapp
-          image: quay.io/uxi/nginx:latest
-          imagePullPolicy: Always
-          env:
-            - name: ENVIRONMENT
-              value: "staging"
-            - name: DD_ENABLED
-              value: "true"
-            - name: DD_ENV
-              value: "staging"
-            - name: DD_SERVICE
-              value: "example-service"
-            - name: DD_TRACE_ENABLED
-              value: "true"
-            - name: DD_AGENT_HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            - name: DD_ENTITY_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
-            - name: SENTRY_ENVIRONMENT
-              value: "staging"
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: example-service-sentry-dsn
-                  key: SENTRY_DSN
-            - name: AWS_DEFAULT_REGION
-              value: "us-west-1"
-            - name: DEBUG
-              value: "false"
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            - name: AWS_REGION
-              valueFrom:
-                secretKeyRef:
-                  name: aws-access
-                  key: AWS_REGION
-            - name: AWS_ACCESS_ID
-              valueFrom:
-                secretKeyRef:
-                  name: aws-access
-                  key: AWS_ACCESS_ID
-            - name: DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: database-url
-                  key: DATABASE_URL
-          ports:
-            - name: http
-              containerPort: 80
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              httpHeaders:
-                - name: Host
-                  value: readinessProbe
-                - name: Content-Type
-                  value: application/json
-              path: /
-              port: 80
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 1
-            successThreshold: 1
-            failureThreshold: 3
-          livenessProbe:
-            httpGet:
-              httpHeaders:
-                - name: Host
-                  value: livenessProbe
-                - name: Content-Type
-                  value: application/json
-              path: /
-              port: 80
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 1
-            successThreshold: 1
-            failureThreshold: 3
-          volumeMounts:
-            - name: config
-              mountPath: /app/config
-              readOnly: true
-            - name: example-service-account
-              mountPath: /tmp
-              readOnly: true
-      volumes:
+      - name: webapp
+        image: quay.io/uxi/nginx:latest
+        imagePullPolicy: Always
+        env:
+        - name: ENVIRONMENT
+          value: "staging"
+        - name: DD_ENABLED
+          value: "true"
+        - name: DD_ENV
+          value: "staging"
+        - name: DD_SERVICE
+          value: "example-service"
+        - name: DD_TRACE_ENABLED
+          value: "true"
+        - name: DD_AGENT_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: DD_ENTITY_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: SENTRY_ENVIRONMENT
+          value: "staging"
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: example-service-sentry-dsn
+              key: SENTRY_DSN        
+        - name: AWS_DEFAULT_REGION
+          value: "us-west-1"
+        - name: DEBUG
+          value: "false"        
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP        
+        - name: AWS_REGION
+          valueFrom:
+            secretKeyRef:
+              name: aws-access
+              key: AWS_REGION
+        - name: AWS_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws-access
+              key: AWS_ACCESS_ID
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: database-url
+              key: DATABASE_URL
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: Host
+              value: readinessProbe
+            - name: Content-Type
+              value: application/json
+            path: /
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: Host
+              value: livenessProbe
+            - name: Content-Type
+              value: application/json
+            path: /
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
+        volumeMounts:
         - name: config
-          configMap:
-            name: example-service
+          mountPath: /app/config
+          readOnly: true
         - name: example-service-account
-          secret:
-            secretName: example-service-account
+          mountPath: /tmp
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: example-service
+      - name: example-service-account
+        secret:
+          secretName: example-service-account
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/deployment.yaml
 apiVersion: apps/v1
@@ -221,7 +221,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -238,37 +238,37 @@ spec:
       labels:
         app.kubernetes.io/name: example-worker
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-3.0.3
+        helm.sh/chart: aruba-uxi-3.1.0
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
         global-label: global-label
     spec:
       imagePullSecrets:
-        - name: aruba-uxi-example-image-pull-secret
+      - name: aruba-uxi-example-image-pull-secret
       containers:
-        - name: worker
-          image: quay.io/uxi/busybox:latest
-          imagePullPolicy: Always
-          command: ["/bin/sh", "-c", "while true; do sleep 3600; date; done;"]
-          env:
-            - name: ENVIRONMENT
-              value: "staging"
-            - name: DD_ENABLED
-              value: "false"
-            - name: SENTRY_ENVIRONMENT
-              value: "staging"
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: example-worker-sentry-dsn
-                  key: SENTRY_DSN
-            - name: DEBUG
-              value: "false"
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
+      - name: worker
+        image: quay.io/uxi/busybox:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh","-c","while true; do sleep 3600; date; done;"]
+        env:
+        - name: ENVIRONMENT
+          value: "staging"
+        - name: DD_ENABLED
+          value: "false"
+        - name: SENTRY_ENVIRONMENT
+          value: "staging"
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: example-worker-sentry-dsn
+              key: SENTRY_DSN        
+        - name: DEBUG
+          value: "false"        
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/cronjob.yaml
 apiVersion: batch/v1beta1
@@ -278,7 +278,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-consumer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -292,29 +292,29 @@ spec:
       template:
         spec:
           imagePullSecrets:
-            - name: aruba-uxi-example-image-pull-secret
+          - name: aruba-uxi-example-image-pull-secret
           containers:
-            - name: example-cronjob-consumer
-              image: quay.io/uxi/busybox:latest
-              imagePullPolicy: Always
-              env:
-                - name: ENVIRONMENT
-                  value: "staging"
-                - name: DD_ENABLED
-                  value: "false"
-                - name: DEBUG
-                  value: "false"
-                - name: HOST_IP
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: status.hostIP
-                - name: AWS_REGION
-                  valueFrom:
-                    secretKeyRef:
-                      name: aws-access
-                      key: AWS_REGION
-              command: ["printenv"]
-              args: ["HOSTNAME"]
+          - name: example-cronjob-consumer
+            image: quay.io/uxi/busybox:latest
+            imagePullPolicy: Always
+            env:
+            - name: ENVIRONMENT
+              value: "staging"
+            - name: DD_ENABLED
+              value: "false"            
+            - name: DEBUG
+              value: "false"            
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP            
+            - name: AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: aws-access
+                  key: AWS_REGION
+            command: ["printenv"]
+            args: ["HOSTNAME"]
           restartPolicy: Never
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/cronjob.yaml
@@ -325,7 +325,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -338,29 +338,24 @@ spec:
       template:
         spec:
           imagePullSecrets:
-            - name: aruba-uxi-example-image-pull-secret
+          - name: aruba-uxi-example-image-pull-secret
           serviceAccountName: example-cronjob-producer
           containers:
-            - name: example-cronjob-producer
-              image: quay.io/uxi/busybox:latest
-              imagePullPolicy: Always
-              env:
-                - name: ENVIRONMENT
-                  value: "staging"
-                - name: DD_ENABLED
-                  value: "false"
-                - name: DEBUG
-                  value: "false"
-                - name: HOST_IP
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: status.hostIP
-              command:
-                [
-                  "/bin/sh",
-                  "-c",
-                  "echo Hello from the example-cronjob-producer",
-                ]
+          - name: example-cronjob-producer
+            image: quay.io/uxi/busybox:latest
+            imagePullPolicy: Always
+            env:
+            - name: ENVIRONMENT
+              value: "staging"
+            - name: DD_ENABLED
+              value: "false"            
+            - name: DEBUG
+              value: "false"            
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP            
+            command: ["/bin/sh","-c","echo Hello from the example-cronjob-producer"]
           restartPolicy: OnFailure
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-ingress.yaml
@@ -371,23 +366,23 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
     example-service-staging: example-service-staging
     global-label: global-label
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: internal-gateway
 spec:
   rules:
-    - host: example-service.staging.capedev.io
-      http:
-        paths:
-          - path: /
-            backend:
-              serviceName: example-service
-              servicePort: 80
+  - host: example-service.staging.capedev.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: example-service
+          servicePort: 80
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-sentry-dsn.yaml
 apiVersion: bitnami.com/v1alpha1
@@ -397,7 +392,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -415,7 +410,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -431,19 +426,20 @@ metadata:
   name: aruba-uxi-example-image-pull-secret
   labels:
     app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     namespace: default
 spec:
   encryptedData:
     .dockerconfigjson: AgC+shUQi6hleq7w05Hcc+Rqjd301LiyLTxn3IjcRac6zS6l5S4f/aonP2iFEff1vN113wTaNoTFbNbHFuklE+WQ68A6cMeyuTe5BlLr0z6d1O8rmuiJrsuHLAq5nzVjlZvf9Kgn0a+OIEYumd6UPKqIyAagIKSiKy+KKMx8j61t3dnlroI7ckapp7NQlvOOZ+onJlOaqF9ahowJ6dDwpWfZKKUm8Bt5W+I3xj9zODh7mMioAo4Snvv4uXD/9QlLzMYJxRFekxEe//F3dquqWBKqeKVYm9rmlpRYopoftT0u9VKLM0EfrWURPv9jSGF4XCqS5rRJsn4URV7gskDkGZr5K/6iu4WGJhRC1+5xdrCMU3/i4AQRaZn3DrqroGWYRW1M2foFhWsg3z8aQkNEeCiBSqfMAycC/nw51bnvGwjglpbm9wHqHtvG3dV9JDQsVlluiEtroM7BsLjMYmx0q7U7WWfzLsiXevJJjBkVHyFq/3Og/5EH23jF3SEdchzInbjjpuBNIETKHGm5wRyTaBve1RA+DstYUWRwB4pFodknT45JuG0r0JLk1hsf5IjRDNam+AlYw0zIJ27vr1hDLjAIDq4wHGc2QO+u0kbL0pXPRtBvrvBlhHT8m7F/Haw/Nt/1URlJ/+HpL5YGsXmZ25J4aHBF3kw8rX9JQGuNS3gfSNP99AvDl5taNeXmzzssJqg8gekcBCjmR5uOSxdtFYUZfhxc4y2fC2dhUeL0O3Q3XytEdJyI70RLg5uKowtokcmqklzXYEeRtOqksV5z2carDqwY+Zk8sJRUWY0gUgVUUo/PtPK4jgrM7saKaj1IYHh/59SNxbpAvV7QzVuExOuqhBVx02s89aMq0GxnRzgH20U3996qBs1DUtrEt9rPio8wNPhN9T7tAK4qytivUgqHmiaV1csrXeXYaWHBWGuzGjyYW9vip2dCkZbZCwdIdx3Mox2B
+
   template:
     data: null
     metadata:
       name: aruba-uxi-example-image-pull-secret
       labels:
       app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-      helm.sh/chart: aruba-uxi-3.0.3
+      helm.sh/chart: aruba-uxi-3.1.0
       app.kubernetes.io/managed-by: Helm
       namespace: default
     type: kubernetes.io/dockerconfigjson
@@ -456,13 +452,14 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-access
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
 spec:
   encryptedData:
     AWS_ACCESS_ID: AgCiBP+jM76iL3njeCm0Ndoj7gvVGhqAluKGevJd7WvbUh+do+SAEFUL+SRlva8rep6YXmGhXsdLG9DtfPtM8YR6L7wvQiDLfVaUi0pcdJf5c6EA5VqznAr7UrMnMratln/TKvUbsLtaPcjwg5jVG0rY4SDCzdmPnzekXChK8AcKAcggm6OA6ITvUfJF01G+kP+e3JvUzEMebT95Cm0E6mdS8GaxTSTZdzEkTOTuPnhRwIvCZZM3Ixha1Ta12U5bXKiWY7BRIXy2yzB1Ck0iEtzA57I1YsxzikY8uj4IXyt/ETJyGt5bp2ezwFzdZInw+/KeuJ8+4/PnDtINnUftQq5VRgcRL583TDnILyk5mcowLwMITYkZVgS3y9rzHcMyQT2UDeF/5g7lQDPWIAcc25DpFYqQxmI+Ud3gmlcXIuGrntb9SwiWIYzmmZD5F85UZCpEfvKcaT761upxgOpMAAt7q19M3MXGB/0a2B5nhCpLuGfa+WbXjAeGeGhSgjLGbHJzgkT7ZGEJkUHoh4mfOTw9vI93UNN2V5jCUuFelEA8+UAZQpVli8Qr4rKrEdnGttYxFzvFVfp/IfvyuXc4ArndzfLu4BZHYqDzh3Qz8pHzx0syFDUHjC7pnjByDGE1EgQyVdp8Qbule5hd1TklRAAbOZE02qrePOkTFULLNpHQ0DkkGuELSjcBJfrQtq73QGSrO8BdOuej5LI=
+
     AWS_REGION: AgDHInk7E4j3jC8zuBrfDirC4bTlUj4nEUk7bnPX8krFC4kWGELObhvcKb2xDkE6dAw39eeAbBUuZXmXq8Jsk1+donH3SZP3BIwng+fjjdCJjKn8Cs/CjNPzH5zvAzpS/GDik5wGCLhaYn9dAe0DXXnq9pRxypjAyv3fAMs3VSMP4pOEzGvBkoqHwzEBXMy+6tGrZepn6RX7sBXutUcg2sl9NUPcfMLC1SrfvCluzqFM0vqSwnyL7QYbjUkCLFh192H4a0LFoV068w6K/rZTMVG5MLXgBziB24lAT0MtY0u1r/xIW1t8PoQuDegcUfr0Cmj5zJI3F7WFn7EoG6qy/2gemO+X5Kzmr28v02t7UiXaBqqWxXU7LsvdUjQ5SGGtOlCeVOXsnCGnBzhVSFPKxRMh3aLKeoRieflnYBQQhEyIAsRA2YY1m6V3rCLAVecnA7NwlpbVOVqCqBTdEj5wI/KsF3GcnUZQ+ceftLHxDPgawLZW5DCeQROF1mR1LxVmJuSb3Aaci8Fc9szusFSto7vz0RhKX2wCJMKf7gTKOSfdUnHc1cw7IG4FjZbA4DE5nVE7LXkPcEXe0dEJ+uUk6a+O+APi20T+dU2p5WiH6W1EjVjLQz3zcR1oKw264uI9iX6Rt/pfudWtR2pmLacUcu5HkEFRqnvpek6qnXUSF52YlEfWgWLbqME2pcoYQJ2hRt2rf/8g0cd3kJPF
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/sealedsecret.yaml
@@ -473,7 +470,7 @@ metadata:
   labels:
     app.kubernetes.io/name: database-url
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -489,7 +486,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service-account
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-3.0.3
+    helm.sh/chart: aruba-uxi-3.1.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -43,14 +43,14 @@ metadata:
     example-service-staging: example-service-staging
     global-label: global-label
 data:
-    config.json: |
-      {
-        foo: bar
-        bing: bang
-        server: {
-          host: hostname
-        }
+  config.json: |
+    {
+      foo: bar
+      bing: bang
+      server: {
+        host: hostname
       }
+    }
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-service.yaml
 apiVersion: v1
@@ -111,107 +111,107 @@ spec:
         global-label: global-label
     spec:
       imagePullSecrets:
-      - name: aruba-uxi-example-image-pull-secret
+        - name: aruba-uxi-example-image-pull-secret
       serviceAccountName: example-service
       containers:
-      - name: webapp
-        image: quay.io/uxi/nginx:latest
-        imagePullPolicy: Always
-        env:
-        - name: ENVIRONMENT
-          value: "staging"
-        - name: DD_ENABLED
-          value: "true"
-        - name: DD_ENV
-          value: "staging"
-        - name: DD_SERVICE
-          value: "example-service"
-        - name: DD_TRACE_ENABLED
-          value: "true"
-        - name: DD_AGENT_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: DD_ENTITY_ID
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.uid
-        - name: SENTRY_ENVIRONMENT
-          value: "staging"
-        - name: SENTRY_DSN
-          valueFrom:
-            secretKeyRef:
-              name: example-service-sentry-dsn
-              key: SENTRY_DSN        
-        - name: AWS_DEFAULT_REGION
-          value: "us-west-1"
-        - name: DEBUG
-          value: "false"        
-        - name: HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP        
-        - name: AWS_REGION
-          valueFrom:
-            secretKeyRef:
-              name: aws-access
-              key: AWS_REGION
-        - name: AWS_ACCESS_ID
-          valueFrom:
-            secretKeyRef:
-              name: aws-access
-              key: AWS_ACCESS_ID
-        - name: DATABASE_URL
-          valueFrom:
-            secretKeyRef:
-              name: database-url
-              key: DATABASE_URL
-        ports:
-        - name: http
-          containerPort: 80
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            httpHeaders:
-            - name: Host
-              value: readinessProbe
-            - name: Content-Type
-              value: application/json
-            path: /
-            port: 80
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 1
-          successThreshold: 1
-          failureThreshold: 3
-        livenessProbe:
-          httpGet:
-            httpHeaders:
-            - name: Host
-              value: livenessProbe
-            - name: Content-Type
-              value: application/json
-            path: /
-            port: 80
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 1
-          successThreshold: 1
-          failureThreshold: 3
-        volumeMounts:
-        - name: config
-          mountPath: /app/config
-          readOnly: true
-        - name: example-service-account
-          mountPath: /tmp
-          readOnly: true
+        - name: webapp
+          image: quay.io/uxi/nginx:latest
+          imagePullPolicy: Always
+          env:
+            - name: ENVIRONMENT
+              value: "staging"
+            - name: DD_ENABLED
+              value: "true"
+            - name: DD_ENV
+              value: "staging"
+            - name: DD_SERVICE
+              value: "example-service"
+            - name: DD_TRACE_ENABLED
+              value: "true"
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_ENTITY_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: SENTRY_ENVIRONMENT
+              value: "staging"
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: example-service-sentry-dsn
+                  key: SENTRY_DSN
+            - name: AWS_DEFAULT_REGION
+              value: "us-west-1"
+            - name: DEBUG
+              value: "false"
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: aws-access
+                  key: AWS_REGION
+            - name: AWS_ACCESS_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws-access
+                  key: AWS_ACCESS_ID
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: database-url
+                  key: DATABASE_URL
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              httpHeaders:
+                - name: Host
+                  value: readinessProbe
+                - name: Content-Type
+                  value: application/json
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              httpHeaders:
+                - name: Host
+                  value: livenessProbe
+                - name: Content-Type
+                  value: application/json
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+            - name: example-service-account
+              mountPath: /tmp
+              readOnly: true
       volumes:
-      - name: config
-        configMap:
-          name: example-service
-      - name: example-service-account
-        secret:
-          secretName: example-service-account
+        - name: config
+          configMap:
+            name: example-service
+        - name: example-service-account
+          secret:
+            secretName: example-service-account
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/deployment.yaml
 apiVersion: apps/v1
@@ -245,30 +245,30 @@ spec:
         global-label: global-label
     spec:
       imagePullSecrets:
-      - name: aruba-uxi-example-image-pull-secret
+        - name: aruba-uxi-example-image-pull-secret
       containers:
-      - name: worker
-        image: quay.io/uxi/busybox:latest
-        imagePullPolicy: Always
-        command: ["/bin/sh","-c","while true; do sleep 3600; date; done;"]
-        env:
-        - name: ENVIRONMENT
-          value: "staging"
-        - name: DD_ENABLED
-          value: "false"
-        - name: SENTRY_ENVIRONMENT
-          value: "staging"
-        - name: SENTRY_DSN
-          valueFrom:
-            secretKeyRef:
-              name: example-worker-sentry-dsn
-              key: SENTRY_DSN        
-        - name: DEBUG
-          value: "false"        
-        - name: HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
+        - name: worker
+          image: quay.io/uxi/busybox:latest
+          imagePullPolicy: Always
+          command: ["/bin/sh", "-c", "while true; do sleep 3600; date; done;"]
+          env:
+            - name: ENVIRONMENT
+              value: "staging"
+            - name: DD_ENABLED
+              value: "false"
+            - name: SENTRY_ENVIRONMENT
+              value: "staging"
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: example-worker-sentry-dsn
+                  key: SENTRY_DSN
+            - name: DEBUG
+              value: "false"
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/cronjob.yaml
 apiVersion: batch/v1beta1
@@ -292,29 +292,29 @@ spec:
       template:
         spec:
           imagePullSecrets:
-          - name: aruba-uxi-example-image-pull-secret
+            - name: aruba-uxi-example-image-pull-secret
           containers:
-          - name: example-cronjob-consumer
-            image: quay.io/uxi/busybox:latest
-            imagePullPolicy: Always
-            env:
-            - name: ENVIRONMENT
-              value: "staging"
-            - name: DD_ENABLED
-              value: "false"            
-            - name: DEBUG
-              value: "false"            
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP            
-            - name: AWS_REGION
-              valueFrom:
-                secretKeyRef:
-                  name: aws-access
-                  key: AWS_REGION
-            command: ["printenv"]
-            args: ["HOSTNAME"]
+            - name: example-cronjob-consumer
+              image: quay.io/uxi/busybox:latest
+              imagePullPolicy: Always
+              env:
+                - name: ENVIRONMENT
+                  value: "staging"
+                - name: DD_ENABLED
+                  value: "false"
+                - name: DEBUG
+                  value: "false"
+                - name: HOST_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: AWS_REGION
+                  valueFrom:
+                    secretKeyRef:
+                      name: aws-access
+                      key: AWS_REGION
+              command: ["printenv"]
+              args: ["HOSTNAME"]
           restartPolicy: Never
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/cronjob.yaml
@@ -338,24 +338,29 @@ spec:
       template:
         spec:
           imagePullSecrets:
-          - name: aruba-uxi-example-image-pull-secret
+            - name: aruba-uxi-example-image-pull-secret
           serviceAccountName: example-cronjob-producer
           containers:
-          - name: example-cronjob-producer
-            image: quay.io/uxi/busybox:latest
-            imagePullPolicy: Always
-            env:
-            - name: ENVIRONMENT
-              value: "staging"
-            - name: DD_ENABLED
-              value: "false"            
-            - name: DEBUG
-              value: "false"            
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP            
-            command: ["/bin/sh","-c","echo Hello from the example-cronjob-producer"]
+            - name: example-cronjob-producer
+              image: quay.io/uxi/busybox:latest
+              imagePullPolicy: Always
+              env:
+                - name: ENVIRONMENT
+                  value: "staging"
+                - name: DD_ENABLED
+                  value: "false"
+                - name: DEBUG
+                  value: "false"
+                - name: HOST_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+              command:
+                [
+                  "/bin/sh",
+                  "-c",
+                  "echo Hello from the example-cronjob-producer",
+                ]
           restartPolicy: OnFailure
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-ingress.yaml
@@ -376,13 +381,13 @@ metadata:
     kubernetes.io/ingress.class: nginx
 spec:
   rules:
-  - host: example-service.staging.capedev.io
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: example-service
-          servicePort: 80
+    - host: example-service.staging.capedev.io
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: example-service
+              servicePort: 80
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-sentry-dsn.yaml
 apiVersion: bitnami.com/v1alpha1

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -379,7 +379,7 @@ spec:
     http:
       paths:
       - path: /
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: example-service

--- a/examples/aruba-uxi-example/values-production.yaml
+++ b/examples/aruba-uxi-example/values-production.yaml
@@ -16,10 +16,10 @@ aruba-uxi:
         example-service-account.json: |
           AgCF2ON/DjK0uf8WKIxTwSuVHDdsFVfHqR9pHrj3htxPDo5ePpJYpfFGzcDBLRzcBOCMZq8I3Z9gUDPXoMPZb+aYc76NTNQxzG/NchS4aekTy3K2FiMiTKS9lzz/WI5CvNXhFoEb06uHy6DR8DbzYn+S+cGsOjlNnU6HvZdn8rqEEGC151IhT0FPVQaiPV4PJkXgHuYCKoCUhsgK80pHsWr8AaUf3r3McbcSYC1eXYVaoy6uhbFsMqZHNOenOooMUsl0xJZ1i/RueKiind9URIKTSxDLG5xEDu5isZgrP22xxzZ1HEolMc+UmtPwDHqr90+Dmnto8vOlLnVN8Mwlj78AZe2SjVp39QRtouKKjKPvNacfSoVkHroSssDLnW3gtucBAthzDe1gAitA0xWV02TYbYnpHcFmx18h1b3UBEmZyfzdtpsU/4oDqNCa1zzL/rBjK4slzTlPvajRgP6GdW+311tOE+W7V2cvwro1u/lqX56dDMp+qLm2SAYAVBGsvbUPqxrcHhD9MMm65HrSU7IBtSqk/91KGtxkrC1pTtVHsav7xlgE9Azv+6iViJ70sTsLbA+4et/jKvu7cHKoLNR7UZ5JINnY1SR0rI8cBIBgvhHq/iu0a2y7eM3LmrFhVYpsM0PAaDeDg4Y0o2XIpF1i0wXBrrZaFLInbUN4Z0uj+MD+k37jDBsSx53JqKrph5qiHvdifZYh8gZ+IfFWNjg=
   global:
-    environment: STAGING
+    environment: PRODUCTION
     image:
       repository: quay.io/uxi/aruba-uxi-example
-      pullPolicy: Always
+      pullPolicy: IfNotPresent
     env:
       DEBUG: false
     envFields:
@@ -33,7 +33,7 @@ aruba-uxi:
         repository: quay.io/uxi/nginx
         tag: latest
       revisionHistoryLimit: 1
-      replicaCount: 1
+      replicaCount: 3
       serviceAccount:
         create: true
       port: 80
@@ -74,14 +74,14 @@ aruba-uxi:
         dsn: |
           AgBgVMiB80V/w/D8lGdVkuwGHPFuscgY814y6bq40L309tYy8r5OGNLBmFiwLkq1P1efmwI0F7KH+DnPehTjRgeqTy5bPP6CjwBbj4aG/0H2fBkscuRP2IVPzsE2CPXQzbxzWu0MCTOUbxfpXwYMZWC5BSpb2voOwobi7Si0y8VGDKOmux0HWHFIjhbm1RacajEan6SJLl7zEYvHpREMQHAvdsVCkPM3DPzFA36UW3YMhn2ki1/2LBAZ6LOoxRAU3/CpLrNyfeHcxVtW4RR25TUzOdfcoiqbE5KoZNJNNEaUk7XvijvoklYDEdNjzwq7hpOZ6LDrWzo0+jjJz6uXWMHK6V8GJKwkxL0nz6+904HNpSoT4D9zsK7hHpp1EK3GK04HFUKlxuEXYRkkRjihSpW25eNgZXeRgKM+9hLApL0do/GE2fJU9kSKxtEHpDSBGNycDLLfMsC5gxctubOmJcklPd8qZ1y+gXlFxPQJPG/7zyK9qN4r1VQ1sIuKEnSdOekQ/tBojvJU7VOalxxX5gA0oXlFGf/4YhgJn6fYtj44EsFE1F05U6IxpgH/nn8tdDZd4jH/EqurwcfS7R2uroXx23IpVmR9El4DsvysU751D1ZP9s6eHq9BkiWMQIhL7vnJTPqOBi9kD1x+74WhPpL6L5qJlB1MLB4okDgHE7TdyPKjHT8tSh0qhJlDQ2mfbzKQcFiri89Vbvheyl3hE/y/8g==
       labels:
-        example-service-staging: example-service-staging
+        example-service-production: example-service-production
       ingress:
+        useLegacyApiVersion: true
         className: internal-gateway
         hosts:
-          - host: example-service.staging.capedev.io
+          - host: example-service.capenetworks.io
             paths:
               - path: /
-                type: Prefix
     example-worker:
       role: worker
       revisionHistoryLimit: 1
@@ -99,7 +99,6 @@ aruba-uxi:
         repository: quay.io/uxi/busybox
         tag: latest
       schedule: "0 * * * *"
-      suspend: true
       command: ["/bin/sh", "-c", "echo Hello from the example-cronjob-producer"]
       serviceAccount:
         create: true
@@ -108,7 +107,6 @@ aruba-uxi:
         repository: quay.io/uxi/busybox
         tag: latest
       schedule: "0 * * * *"
-      suspend: true
       command: ["printenv"]
       args: ["HOSTNAME"]
       restartPolicy: Never
@@ -116,4 +114,4 @@ aruba-uxi:
         aws-access:
           - AWS_REGION
       labels:
-        example-cronjob-consumer-staging: example-cronjob-consumer-staging
+        example-cronjob-consumer-production: example-cronjob-consumer-production

--- a/examples/aruba-uxi-example/values-staging.yaml
+++ b/examples/aruba-uxi-example/values-staging.yaml
@@ -81,7 +81,6 @@ aruba-uxi:
           - host: example-service.staging.capedev.io
             paths:
               - path: /
-                type: Prefix
     example-worker:
       role: worker
       revisionHistoryLimit: 1

--- a/examples/aruba-uxi-example/values-staging.yaml
+++ b/examples/aruba-uxi-example/values-staging.yaml
@@ -76,6 +76,7 @@ aruba-uxi:
       labels:
         example-service-staging: example-service-staging
       ingress:
+        useLegacyApiVersion: true
         className: internal-gateway
         hosts:
           - host: example-service.staging.capedev.io

--- a/examples/aruba-uxi-example/values-staging.yaml
+++ b/examples/aruba-uxi-example/values-staging.yaml
@@ -1,19 +1,19 @@
 aruba-uxi:
   sealedSecrets:
-    imagePullSecret:
+    imagePullSecret: |
       AgC+shUQi6hleq7w05Hcc+Rqjd301LiyLTxn3IjcRac6zS6l5S4f/aonP2iFEff1vN113wTaNoTFbNbHFuklE+WQ68A6cMeyuTe5BlLr0z6d1O8rmuiJrsuHLAq5nzVjlZvf9Kgn0a+OIEYumd6UPKqIyAagIKSiKy+KKMx8j61t3dnlroI7ckapp7NQlvOOZ+onJlOaqF9ahowJ6dDwpWfZKKUm8Bt5W+I3xj9zODh7mMioAo4Snvv4uXD/9QlLzMYJxRFekxEe//F3dquqWBKqeKVYm9rmlpRYopoftT0u9VKLM0EfrWURPv9jSGF4XCqS5rRJsn4URV7gskDkGZr5K/6iu4WGJhRC1+5xdrCMU3/i4AQRaZn3DrqroGWYRW1M2foFhWsg3z8aQkNEeCiBSqfMAycC/nw51bnvGwjglpbm9wHqHtvG3dV9JDQsVlluiEtroM7BsLjMYmx0q7U7WWfzLsiXevJJjBkVHyFq/3Og/5EH23jF3SEdchzInbjjpuBNIETKHGm5wRyTaBve1RA+DstYUWRwB4pFodknT45JuG0r0JLk1hsf5IjRDNam+AlYw0zIJ27vr1hDLjAIDq4wHGc2QO+u0kbL0pXPRtBvrvBlhHT8m7F/Haw/Nt/1URlJ/+HpL5YGsXmZ25J4aHBF3kw8rX9JQGuNS3gfSNP99AvDl5taNeXmzzssJqg8gekcBCjmR5uOSxdtFYUZfhxc4y2fC2dhUeL0O3Q3XytEdJyI70RLg5uKowtokcmqklzXYEeRtOqksV5z2carDqwY+Zk8sJRUWY0gUgVUUo/PtPK4jgrM7saKaj1IYHh/59SNxbpAvV7QzVuExOuqhBVx02s89aMq0GxnRzgH20U3996qBs1DUtrEt9rPio8wNPhN9T7tAK4qytivUgqHmiaV1csrXeXYaWHBWGuzGjyYW9vip2dCkZbZCwdIdx3Mox2B
     env:
       aws-access:
-        AWS_REGION:
+        AWS_REGION: |
           AgDHInk7E4j3jC8zuBrfDirC4bTlUj4nEUk7bnPX8krFC4kWGELObhvcKb2xDkE6dAw39eeAbBUuZXmXq8Jsk1+donH3SZP3BIwng+fjjdCJjKn8Cs/CjNPzH5zvAzpS/GDik5wGCLhaYn9dAe0DXXnq9pRxypjAyv3fAMs3VSMP4pOEzGvBkoqHwzEBXMy+6tGrZepn6RX7sBXutUcg2sl9NUPcfMLC1SrfvCluzqFM0vqSwnyL7QYbjUkCLFh192H4a0LFoV068w6K/rZTMVG5MLXgBziB24lAT0MtY0u1r/xIW1t8PoQuDegcUfr0Cmj5zJI3F7WFn7EoG6qy/2gemO+X5Kzmr28v02t7UiXaBqqWxXU7LsvdUjQ5SGGtOlCeVOXsnCGnBzhVSFPKxRMh3aLKeoRieflnYBQQhEyIAsRA2YY1m6V3rCLAVecnA7NwlpbVOVqCqBTdEj5wI/KsF3GcnUZQ+ceftLHxDPgawLZW5DCeQROF1mR1LxVmJuSb3Aaci8Fc9szusFSto7vz0RhKX2wCJMKf7gTKOSfdUnHc1cw7IG4FjZbA4DE5nVE7LXkPcEXe0dEJ+uUk6a+O+APi20T+dU2p5WiH6W1EjVjLQz3zcR1oKw264uI9iX6Rt/pfudWtR2pmLacUcu5HkEFRqnvpek6qnXUSF52YlEfWgWLbqME2pcoYQJ2hRt2rf/8g0cd3kJPF
-        AWS_ACCESS_ID:
+        AWS_ACCESS_ID: |
           AgCiBP+jM76iL3njeCm0Ndoj7gvVGhqAluKGevJd7WvbUh+do+SAEFUL+SRlva8rep6YXmGhXsdLG9DtfPtM8YR6L7wvQiDLfVaUi0pcdJf5c6EA5VqznAr7UrMnMratln/TKvUbsLtaPcjwg5jVG0rY4SDCzdmPnzekXChK8AcKAcggm6OA6ITvUfJF01G+kP+e3JvUzEMebT95Cm0E6mdS8GaxTSTZdzEkTOTuPnhRwIvCZZM3Ixha1Ta12U5bXKiWY7BRIXy2yzB1Ck0iEtzA57I1YsxzikY8uj4IXyt/ETJyGt5bp2ezwFzdZInw+/KeuJ8+4/PnDtINnUftQq5VRgcRL583TDnILyk5mcowLwMITYkZVgS3y9rzHcMyQT2UDeF/5g7lQDPWIAcc25DpFYqQxmI+Ud3gmlcXIuGrntb9SwiWIYzmmZD5F85UZCpEfvKcaT761upxgOpMAAt7q19M3MXGB/0a2B5nhCpLuGfa+WbXjAeGeGhSgjLGbHJzgkT7ZGEJkUHoh4mfOTw9vI93UNN2V5jCUuFelEA8+UAZQpVli8Qr4rKrEdnGttYxFzvFVfp/IfvyuXc4ArndzfLu4BZHYqDzh3Qz8pHzx0syFDUHjC7pnjByDGE1EgQyVdp8Qbule5hd1TklRAAbOZE02qrePOkTFULLNpHQ0DkkGuELSjcBJfrQtq73QGSrO8BdOuej5LI=
       database-url:
-        DATABASE_URL:
+        DATABASE_URL: |
           AgAuvJH6oRC1EklejbecyiSvse4HcCn/VqZcZectp14ZKp/fZlekWVWMQR9eBmXGr4QIfgbMeDNdMXfh+3g2GaXSA+8z2gNTQQWqweyy9WBnXyOG6uJD/yFXXz1mIACAektFMUNqAIDGTIUahcdGwCtRqUaq7ikOyx0HWo6ZtTE2DKYvRUZG8226pm6s4HQNW9aMwgpsmrZYZYQUOiO5yFeuUA/CdoxkzK6G7ArtQj2dRXKRH5p4/foBvXZpVTegWu2ATnfEJf+VVs0jNpAoDk5+shg5grH8GHTD/COmf8SCEdiKk6HZhWof8di+l+l9eTx+1rcAuMPZnNvOuW8G2b8Cb4V71vcg5O3ONJnyLcSW0mL4o66qpK+z3DBZq10r3fnMEWBUVnDdzZcUDWs6UoVjj/rBleKzLGNkbRTqvXbzqdxbjq1w1yLHQMw2WzxLfARwM08LOT91C2egL7RyjBjBSM/TjPzMzMzZkbu7U0d46GVI6/H3mPOc831o5cLncBjxph6Nx/mrS/NA6Nai56OI7wfXK5cIYJKX+Ch47Qewj80CZjHnud8n2aZqrsk4nAp+ZX6yAThQIq8ytg21oZYwOcTSbBfwlzEqjJP5jBMzIIrxauXsHiIAjcjpaQ40mkFI7mJpwGgcxPMtJglC29yDTdRctakht2EMXs7r2GO5llI//nOzlheq5PnstyaoiwPMO47ebk+MRXNtxiUxhHmXeeLXe7ZKkHegKERTrPYyZCjY
     secretMount:
       example-service-account:
-        example-service-account.json:
+        example-service-account.json: |
           AgCF2ON/DjK0uf8WKIxTwSuVHDdsFVfHqR9pHrj3htxPDo5ePpJYpfFGzcDBLRzcBOCMZq8I3Z9gUDPXoMPZb+aYc76NTNQxzG/NchS4aekTy3K2FiMiTKS9lzz/WI5CvNXhFoEb06uHy6DR8DbzYn+S+cGsOjlNnU6HvZdn8rqEEGC151IhT0FPVQaiPV4PJkXgHuYCKoCUhsgK80pHsWr8AaUf3r3McbcSYC1eXYVaoy6uhbFsMqZHNOenOooMUsl0xJZ1i/RueKiind9URIKTSxDLG5xEDu5isZgrP22xxzZ1HEolMc+UmtPwDHqr90+Dmnto8vOlLnVN8Mwlj78AZe2SjVp39QRtouKKjKPvNacfSoVkHroSssDLnW3gtucBAthzDe1gAitA0xWV02TYbYnpHcFmx18h1b3UBEmZyfzdtpsU/4oDqNCa1zzL/rBjK4slzTlPvajRgP6GdW+311tOE+W7V2cvwro1u/lqX56dDMp+qLm2SAYAVBGsvbUPqxrcHhD9MMm65HrSU7IBtSqk/91KGtxkrC1pTtVHsav7xlgE9Azv+6iViJ70sTsLbA+4et/jKvu7cHKoLNR7UZ5JINnY1SR0rI8cBIBgvhHq/iu0a2y7eM3LmrFhVYpsM0PAaDeDg4Y0o2XIpF1i0wXBrrZaFLInbUN4Z0uj+MD+k37jDBsSx53JqKrph5qiHvdifZYh8gZ+IfFWNjg=
   global:
     environment: STAGING
@@ -55,9 +55,9 @@ aruba-uxi:
               }
             }
       secretMount:
-      - name: example-service-account
-        readOnly: true
-        path: /tmp
+        - name: example-service-account
+          readOnly: true
+          path: /tmp
       env:
         AWS_DEFAULT_REGION: us-west-1
       envSealedSecrets:
@@ -71,27 +71,26 @@ aruba-uxi:
         traceEnabled: true
       sentry:
         enabled: true
-        dsn:
+        dsn: |
           AgBgVMiB80V/w/D8lGdVkuwGHPFuscgY814y6bq40L309tYy8r5OGNLBmFiwLkq1P1efmwI0F7KH+DnPehTjRgeqTy5bPP6CjwBbj4aG/0H2fBkscuRP2IVPzsE2CPXQzbxzWu0MCTOUbxfpXwYMZWC5BSpb2voOwobi7Si0y8VGDKOmux0HWHFIjhbm1RacajEan6SJLl7zEYvHpREMQHAvdsVCkPM3DPzFA36UW3YMhn2ki1/2LBAZ6LOoxRAU3/CpLrNyfeHcxVtW4RR25TUzOdfcoiqbE5KoZNJNNEaUk7XvijvoklYDEdNjzwq7hpOZ6LDrWzo0+jjJz6uXWMHK6V8GJKwkxL0nz6+904HNpSoT4D9zsK7hHpp1EK3GK04HFUKlxuEXYRkkRjihSpW25eNgZXeRgKM+9hLApL0do/GE2fJU9kSKxtEHpDSBGNycDLLfMsC5gxctubOmJcklPd8qZ1y+gXlFxPQJPG/7zyK9qN4r1VQ1sIuKEnSdOekQ/tBojvJU7VOalxxX5gA0oXlFGf/4YhgJn6fYtj44EsFE1F05U6IxpgH/nn8tdDZd4jH/EqurwcfS7R2uroXx23IpVmR9El4DsvysU751D1ZP9s6eHq9BkiWMQIhL7vnJTPqOBi9kD1x+74WhPpL6L5qJlB1MLB4okDgHE7TdyPKjHT8tSh0qhJlDQ2mfbzKQcFiri89Vbvheyl3hE/y/8g==
       labels:
         example-service-staging: example-service-staging
       ingress:
-        className: nginx
-        enabled: true
+        className: internal-gateway
         hosts:
-        - host: example-service.staging.capedev.io
-          paths:
-            - path: /
+          - host: example-service.staging.capedev.io
+            paths:
+              - path: /
     example-worker:
       role: worker
       revisionHistoryLimit: 1
       image:
         repository: quay.io/uxi/busybox
         tag: latest
-      command: ["/bin/sh", "-c", 'while true; do sleep 3600; date; done;']
+      command: ["/bin/sh", "-c", "while true; do sleep 3600; date; done;"]
       sentry:
         enabled: true
-        dsn:
+        dsn: |
           AgBsCKUK1LVkqXFrIoqKHzUPCpH0cm2QomH5/d4f+ZgwaBBTKAOmOo0QBZz90BgJDAk3EwArlAw7EgACDkrbVJzHYofs/peFUvB8JO5jYZDjL5HnJ9Uyj1upE1/tBCZhzswKs/WIesRHZKseDgLSmE7//z8F9obVAKn6ECYMB4nhazfzJivDTRsbGZrgb0u0NDFdHRUhpNeBmclrheatz/ZtUL1Vbyvne1zQfRvBz7pGhzxLFFk/q5O//UmqAAWy6WRm6u0mWbvDM8CUmCzPkIBH4+pTuAT+2u/pbSrUGMKf9tEw5brqySPg7c/+jcaJUMY3cCNCIMxf9Zb83CuhqIggZpZfNBaGaYHiAU4BGELCEnk74uW/09A5/Qu1vY7wZYrfMJn3RTz8+jmXGxVyzmPzPyL7veOJwX2ajhRBbUQOtExcd2AFiMwbb3elgGY01rFuxvujq2ppqymGlkwjetWjQWUfKZ91CnBEEfnOz5PWnevoaN7acFzP2aRp7/qpZhN+mcl1jXp0ESVP3BptD8fhNdsnhpEra8dVZLJ2CXGXP+ubZUGrbV6kuccGwkg12dZjwBHYIZQ8akZNZjYRD+x6V6tah0dyVcedJgk7Zlx9mreCg9zW2ZQGL3Bhcjw9ZoxQTLkhWA6zodWxot/n73WIAsQfHYw177VJB9xWnPhZFolgS3iPkRHTalteSvBBsvRmNm8c052CzBY5uhaZp1ugjw==
   cronjobs:
     example-cronjob-producer:
@@ -114,6 +113,6 @@ aruba-uxi:
       restartPolicy: Never
       envSealedSecrets:
         aws-access:
-        - AWS_REGION
+          - AWS_REGION
       labels:
         example-cronjob-consumer-staging: example-cronjob-consumer-staging


### PR DESCRIPTION
## Description

K8s in production can not use the newer ingress `apiVersion`. This allows the service to choose which style of ingress it uses. If setting the `ingress.useLegacyApiVersion` to `true`, the `extensions/v1beta1` version will be used, else `networking.k8s.io/v1` is used.

## Types of changes

_Put an `x` in the boxes that apply._

- [x] Bugfix (`fix`): A non-breaking change which fixes an issue or bug
- [x] New Feature (`feat`): A non-breaking change which adds a new feature or new functionality
- [ ] Tests (`test`): Adding missing tests or correcting existing tests
- [ ] Refactoring (`refactor`): A code change that neither fixes a bug nor adds a feature, e.g Deleting unused or redundant code
- [ ] Documentation (`docs`): Documentation only changes
- [ ] Other (`style`, `build`, `ci`, `performance`): Formatting, linting or styling. Changes to the CI pipeline. Performance improvements. Changes that affect the build system.
