### PR TITLE
feat: configmaps create optional and fix logic bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - what has been changed
 
-## [5.0.0] - 2022-03-18
+## [5.0.0] - 2022-03-31
 
 ### Changed
 
 - We can now create multiple configMaps per application
 - ConfigMaps have new field `create` which defines whether the ConfigMap must be created or not
+- ConfigMaps have new field `name` which affects the ConfigMap name field that the deployment links to
 - Fix logic bug where false values are defaulting to true
 
 ## [4.1.1] - 2022-03-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - what has been changed
 
+## [5.0.0] - 2022-03-18
+
+### Changed
+
+- We can now create multiple configMaps per application
+- ConfigMaps have new field `create` which defines whether the ConfigMap must be created or not
+- Fix logic bug where false values are defaulting to true
+
 ## [4.1.1] - 2022-03-18
 
 ### Changed
 
 - update default replicas to 1
-
--
 
 ## [4.1.0] - 2022-03-10
 

--- a/charts/aruba-uxi/Chart.yaml
+++ b/charts/aruba-uxi/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: aruba-uxi
 description: A Helm chart for Aruba UXI kubernetes resources
 type: application
-version: 4.1.1
+version: 5.0.0
 maintainers:
   - name: Aruba-UXI

--- a/charts/aruba-uxi/README.md
+++ b/charts/aruba-uxi/README.md
@@ -131,8 +131,10 @@ In this table `application` refers to each application defined under `applicatio
 | application.affinity | Affinity to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for more details on the structure | `{}` | Yes |
 | application.securityContext | Sets the security contextfor the pods. See [link](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for more details on the structure | `{}` | Yes |
 | application.configMap | A config map to create and apply to the application | | Yes |
+| application.configMap.create | Whether to create the config map | `true` | Yes |
+| application.configMap.name | The name of the config map | `configmap` | Yes |
 | application.configMap.annotations | Annotations to add to the config map | `{}` | Yes |
-| application.configMap.readOnly | Whether the configmap is mapped as readonly or not | `true` | Yes |
+| application.configMap.readOnly | Whether the config map is mapped as readonly or not | `true` | Yes |
 | application.configMap.path | The path to map the config map to in the pod | `{}` | Yes |
 | application.configMap.data | The data to add to the config map | `{}` | Yes |
 | application.secretMount | A secret mount to add secrets as a file to the pod | | Yes |

--- a/charts/aruba-uxi/README.md
+++ b/charts/aruba-uxi/README.md
@@ -131,8 +131,8 @@ In this table `application` refers to each application defined under `applicatio
 | application.affinity | Affinity to set on the pod. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for more details on the structure | `{}` | Yes |
 | application.securityContext | Sets the security contextfor the pods. See [link](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for more details on the structure | `{}` | Yes |
 | application.configMap | A config map to create and apply to the application | | Yes |
-| application.configMap.create | Whether to create the config map | `true` | Yes |
-| application.configMap.name | The name of the config map | `configmap` | Yes |
+| application.configMap.create | Whether to create the config map | | No |
+| application.configMap.name | The name of the config map | | No |
 | application.configMap.annotations | Annotations to add to the config map | `{}` | Yes |
 | application.configMap.readOnly | Whether the config map is mapped as readonly or not | `true` | Yes |
 | application.configMap.path | The path to map the config map to in the pod | `{}` | Yes |

--- a/charts/aruba-uxi/templates/application-configmap.yaml
+++ b/charts/aruba-uxi/templates/application-configmap.yaml
@@ -1,17 +1,20 @@
 {{- range $name, $data := .Values.applications }}
 {{- $additionalLabels := deepCopy (default dict $.Values.global.labels) | mustMerge (default dict $data.labels) }}
-{{- if $data.configMap }}
+{{- $configMaps := default dict $data.configMap }}
+{{- range $configMap := $configMaps}}
+{{- if or $configMap.create (not (hasKey $configMap "create")) }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $name }}
+  name: {{ default $name $configMap.name }}
   labels:
     {{- include "aruba-uxi.labels" (dict "context" $ "name" $name "additionalLabels" $additionalLabels) | nindent 4 }}
-  {{- with $data.configMap.annotations }}
+  {{- with $configMap.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-data: {{- toYaml $data.configMap.data | nindent 4 }}
+data: {{- toYaml $configMap.data | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/aruba-uxi/templates/application-configmap.yaml
+++ b/charts/aruba-uxi/templates/application-configmap.yaml
@@ -2,12 +2,12 @@
 {{- $additionalLabels := deepCopy (default dict $.Values.global.labels) | mustMerge (default dict $data.labels) }}
 {{- $configMaps := default dict $data.configMap }}
 {{- range $configMap := $configMaps}}
-{{- if or $configMap.create (not (hasKey $configMap "create")) }}
+{{- if $configMap.create }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ default $name $configMap.name }}
+  name: {{ $configMap.name }}
   labels:
     {{- include "aruba-uxi.labels" (dict "context" $ "name" $name "additionalLabels" $additionalLabels) | nindent 4 }}
   {{- with $configMap.annotations }}

--- a/charts/aruba-uxi/templates/configmap.yaml
+++ b/charts/aruba-uxi/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-configmap02
+data.txt:
+  hello config maps

--- a/charts/aruba-uxi/templates/configmap.yaml
+++ b/charts/aruba-uxi/templates/configmap.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-configmap02
-data.txt:
-  hello config maps
+data:
+  hello: goodbye

--- a/charts/aruba-uxi/templates/deployment.yaml
+++ b/charts/aruba-uxi/templates/deployment.yaml
@@ -129,15 +129,17 @@ spec:
         {{- if or $data.configMap $data.secretMount }}
         volumeMounts:
         {{- if $data.configMap }}
-        - name: config
-          mountPath: {{ $data.configMap.path }}
-          readOnly: {{ default true $data.configMap.readOnly }}
+        {{- range $configMapData := $data.configMap }}
+        - name: {{ default "configmap" $configMapData.name }}
+          mountPath: {{ $configMapData.path }}
+          readOnly: {{ or $configMapData.readOnly (not (hasKey $configMapData "readOnly")) }}
+        {{- end }}
         {{- end }}
         {{- if $data.secretMount }}
         {{- range $secretMountData := $data.secretMount }}
         - name: {{ $secretMountData.name }}
           mountPath: {{ $secretMountData.path}}
-          readOnly: {{ default true $secretMountData.readOnly }}
+          readOnly: {{ or $secretMountData.readOnly (not (hasKey $secretMountData "readOnly")) }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/charts/aruba-uxi/templates/deployment.yaml
+++ b/charts/aruba-uxi/templates/deployment.yaml
@@ -130,7 +130,7 @@ spec:
         volumeMounts:
         {{- if $data.configMap }}
         {{- range $configMapData := $data.configMap }}
-        - name: {{ default "configmap" $configMapData.name }}
+        - name: {{ $configMapData.name }}
           mountPath: {{ $configMapData.path }}
           readOnly: {{ or $configMapData.readOnly (not (hasKey $configMapData "readOnly")) }}
         {{- end }}

--- a/charts/aruba-uxi/templates/deployment.yaml
+++ b/charts/aruba-uxi/templates/deployment.yaml
@@ -130,7 +130,7 @@ spec:
         volumeMounts:
         {{- if $data.configMap }}
         {{- range $configMapData := $data.configMap }}
-        - name: {{ $configMapData.name }}
+        - name: {{ $configMapData.name }}-volume
           mountPath: {{ $configMapData.path }}
           readOnly: {{ or $configMapData.readOnly (not (hasKey $configMapData "readOnly")) }}
         {{- end }}
@@ -158,9 +158,11 @@ spec:
       {{- if or $data.configMap $data.secretMount }}
       volumes:
       {{- if $data.configMap }}
-      - name: config
+      {{- range $configMapData := $data.configMap }}
+      - name: {{ $configMapData.name }}-volume
         configMap:
-          name: {{ $name }}
+          name: {{ $configMapData.name }}
+      {{- end }}
       {{- end }}
       {{- if $data.secretMount }}
       {{- range $secretMountData := $data.secretMount }}

--- a/charts/aruba-uxi/values.example.yaml
+++ b/charts/aruba-uxi/values.example.yaml
@@ -167,18 +167,18 @@ aruba-uxi:
       ## Default: None
       ###
       configMap:
-        annotations: {}
-        readOnly: false
-        path: /app/config
-        data:
-          config.json: |
-            {
-              foo: bar
-              bing: bang
-              server: {
-                host: hostname
+        - annotations: {}
+          readOnly: false
+          path: /app/config
+          data:
+            config.json: |
+              {
+                foo: bar
+                bing: bang
+                server: {
+                  host: hostname
+                }
               }
-            }
       ## Environment variables set from provided key:value pair (Optional)
       ## If overridden, in application or cronjobs, precedence is given to the overridden values
       ## Default: None

--- a/charts/aruba-uxi/values.example.yaml
+++ b/charts/aruba-uxi/values.example.yaml
@@ -167,7 +167,9 @@ aruba-uxi:
       ## Default: None
       ###
       configMap:
-        - annotations: {}
+        - name: example-configmap01
+          create: true
+          annotations: {}
           readOnly: false
           path: /app/config
           data:
@@ -179,6 +181,11 @@ aruba-uxi:
                   host: hostname
                 }
               }
+        - name: example-configmap02
+          create: false
+          annotations: {}
+          readOnly: false
+          path: /app/config
       ## Environment variables set from provided key:value pair (Optional)
       ## If overridden, in application or cronjobs, precedence is given to the overridden values
       ## Default: None

--- a/examples/aruba-uxi-example/output-local.yaml
+++ b/examples/aruba-uxi-example/output-local.yaml
@@ -1,4 +1,12 @@
 ---
+# Source: aruba-uxi-example/charts/aruba-uxi/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-configmap02
+data.txt:
+  hello config maps
+---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-service.yaml
 apiVersion: v1
 kind: Service

--- a/examples/aruba-uxi-example/output-local.yaml
+++ b/examples/aruba-uxi-example/output-local.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -30,7 +30,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -46,7 +46,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-4.1.1
+        helm.sh/chart: aruba-uxi-5.0.0
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default

--- a/examples/aruba-uxi-example/output-local.yaml
+++ b/examples/aruba-uxi-example/output-local.yaml
@@ -4,8 +4,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-configmap02
-data.txt:
-  hello config maps
+data:
+  hello: goodbye
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-service.yaml
 apiVersion: v1

--- a/examples/aruba-uxi-example/output-production.yaml
+++ b/examples/aruba-uxi-example/output-production.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -36,7 +36,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -60,7 +60,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -85,7 +85,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -103,7 +103,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-4.1.1
+        helm.sh/chart: aruba-uxi-5.0.0
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -201,8 +201,11 @@ spec:
           successThreshold: 1
           failureThreshold: 3
         volumeMounts:
-        - name: config
+        - name: configmap
           mountPath: /app/config
+          readOnly: false
+        - name: example-configmap
+          mountPath: /app/config/example-configmap
           readOnly: true
         - name: example-service-account
           mountPath: /tmp
@@ -223,7 +226,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -240,7 +243,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-worker
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-4.1.1
+        helm.sh/chart: aruba-uxi-5.0.0
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -282,7 +285,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-consumer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -331,7 +334,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -374,7 +377,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -404,7 +407,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -422,7 +425,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -438,7 +441,7 @@ metadata:
   name: aruba-uxi-example-image-pull-secret
   labels:
     app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     namespace: default
 spec:
@@ -450,7 +453,7 @@ spec:
       name: aruba-uxi-example-image-pull-secret
       labels:
       app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-      helm.sh/chart: aruba-uxi-4.1.1
+      helm.sh/chart: aruba-uxi-5.0.0
       app.kubernetes.io/managed-by: Helm
       namespace: default
     type: kubernetes.io/dockerconfigjson
@@ -463,7 +466,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-access
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -480,7 +483,7 @@ metadata:
   labels:
     app.kubernetes.io/name: database-url
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -496,7 +499,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service-account
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default

--- a/examples/aruba-uxi-example/output-production.yaml
+++ b/examples/aruba-uxi-example/output-production.yaml
@@ -57,8 +57,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-configmap02
-data.txt:
-  hello config maps
+data:
+  hello: goodbye
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-service.yaml
 apiVersion: v1

--- a/examples/aruba-uxi-example/output-production.yaml
+++ b/examples/aruba-uxi-example/output-production.yaml
@@ -32,7 +32,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-service
+  name: example-configmap01
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
@@ -51,6 +51,14 @@ data:
           host: hostname
         }
       }
+---
+# Source: aruba-uxi-example/charts/aruba-uxi/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-configmap02
+data.txt:
+  hello config maps
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-service.yaml
 apiVersion: v1
@@ -201,10 +209,10 @@ spec:
           successThreshold: 1
           failureThreshold: 3
         volumeMounts:
-        - name: configmap
+        - name: example-configmap01
           mountPath: /app/config
           readOnly: false
-        - name: example-configmap
+        - name: example-configmap02
           mountPath: /app/config/example-configmap
           readOnly: true
         - name: example-service-account

--- a/examples/aruba-uxi-example/output-production.yaml
+++ b/examples/aruba-uxi-example/output-production.yaml
@@ -209,19 +209,22 @@ spec:
           successThreshold: 1
           failureThreshold: 3
         volumeMounts:
-        - name: example-configmap01
+        - name: example-configmap01-volume
           mountPath: /app/config
           readOnly: false
-        - name: example-configmap02
+        - name: example-configmap02-volume
           mountPath: /app/config/example-configmap
           readOnly: true
         - name: example-service-account
           mountPath: /tmp
           readOnly: true
       volumes:
-      - name: config
+      - name: example-configmap01-volume
         configMap:
-          name: example-service
+          name: example-configmap01
+      - name: example-configmap02-volume
+        configMap:
+          name: example-configmap02
       - name: example-service-account
         secret:
           secretName: example-service-account

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -32,7 +32,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-service
+  name: example-configmap01
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
@@ -51,6 +51,14 @@ data:
           host: hostname
         }
       }
+---
+# Source: aruba-uxi-example/charts/aruba-uxi/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-configmap02
+data.txt:
+  hello config maps
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-service.yaml
 apiVersion: v1
@@ -187,10 +195,10 @@ spec:
           successThreshold: 1
           failureThreshold: 3
         volumeMounts:
-        - name: configmap
+        - name: example-configmap01
           mountPath: /app/config
           readOnly: false
-        - name: example-configmap
+        - name: example-configmap02
           mountPath: /app/config/example-configmap
           readOnly: true
         - name: example-service-account

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -57,8 +57,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-configmap02
-data.txt:
-  hello config maps
+data:
+  hello: goodbye
 ---
 # Source: aruba-uxi-example/charts/aruba-uxi/templates/application-service.yaml
 apiVersion: v1

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -36,7 +36,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -60,7 +60,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -85,7 +85,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -103,7 +103,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-4.1.1
+        helm.sh/chart: aruba-uxi-5.0.0
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -187,8 +187,11 @@ spec:
           successThreshold: 1
           failureThreshold: 3
         volumeMounts:
-        - name: config
+        - name: configmap
           mountPath: /app/config
+          readOnly: false
+        - name: example-configmap
+          mountPath: /app/config/example-configmap
           readOnly: true
         - name: example-service-account
           mountPath: /tmp
@@ -209,7 +212,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -226,7 +229,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-worker
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-4.1.1
+        helm.sh/chart: aruba-uxi-5.0.0
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -268,7 +271,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-consumer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -317,7 +320,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -360,7 +363,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -393,7 +396,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -411,7 +414,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -427,7 +430,7 @@ metadata:
   name: aruba-uxi-example-image-pull-secret
   labels:
     app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     namespace: default
 spec:
@@ -439,7 +442,7 @@ spec:
       name: aruba-uxi-example-image-pull-secret
       labels:
       app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-      helm.sh/chart: aruba-uxi-4.1.1
+      helm.sh/chart: aruba-uxi-5.0.0
       app.kubernetes.io/managed-by: Helm
       namespace: default
     type: kubernetes.io/dockerconfigjson
@@ -452,7 +455,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-access
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -469,7 +472,7 @@ metadata:
   labels:
     app.kubernetes.io/name: database-url
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -485,7 +488,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service-account
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-4.1.1
+    helm.sh/chart: aruba-uxi-5.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -195,19 +195,22 @@ spec:
           successThreshold: 1
           failureThreshold: 3
         volumeMounts:
-        - name: example-configmap01
+        - name: example-configmap01-volume
           mountPath: /app/config
           readOnly: false
-        - name: example-configmap02
+        - name: example-configmap02-volume
           mountPath: /app/config/example-configmap
           readOnly: true
         - name: example-service-account
           mountPath: /tmp
           readOnly: true
       volumes:
-      - name: config
+      - name: example-configmap01-volume
         configMap:
-          name: example-service
+          name: example-configmap01
+      - name: example-configmap02-volume
+        configMap:
+          name: example-configmap02
       - name: example-service-account
         secret:
           secretName: example-service-account

--- a/examples/aruba-uxi-example/values-production.yaml
+++ b/examples/aruba-uxi-example/values-production.yaml
@@ -37,7 +37,9 @@ aruba-uxi:
       readinessProbe:
         enabled: true
       configMap:
-        - annotations: {}
+        - name: example-configmap01
+          create: true
+          annotations: {}
           readOnly: false
           path: /app/config
           data:
@@ -49,7 +51,7 @@ aruba-uxi:
                   host: hostname
                 }
               }
-        - name: example-configmap
+        - name: example-configmap02
           create: false
           readOnly: true
           path: /app/config/example-configmap

--- a/examples/aruba-uxi-example/values-production.yaml
+++ b/examples/aruba-uxi-example/values-production.yaml
@@ -37,18 +37,22 @@ aruba-uxi:
       readinessProbe:
         enabled: true
       configMap:
-        annotations: {}
-        readOnly: false
-        path: /app/config
-        data:
-          config.json: |
-            {
-              foo: bar
-              bing: bang
-              server: {
-                host: hostname
+        - annotations: {}
+          readOnly: false
+          path: /app/config
+          data:
+            config.json: |
+              {
+                foo: bar
+                bing: bang
+                server: {
+                  host: hostname
+                }
               }
-            }
+        - name: example-configmap
+          create: false
+          readOnly: true
+          path: /app/config/example-configmap
       secretMount:
         - name: example-service-account
           readOnly: true

--- a/examples/aruba-uxi-example/values-staging.yaml
+++ b/examples/aruba-uxi-example/values-staging.yaml
@@ -39,18 +39,23 @@ aruba-uxi:
         enabled: false
         path: /
       configMap:
-        annotations: {}
-        readOnly: false
-        path: /app/config
-        data:
-          config.json: |
-            {
-              foo: bar
-              bing: bang
-              server: {
-                host: hostname
+        - create: true
+          annotations: {}
+          readOnly: false
+          path: /app/config
+          data:
+            config.json: |
+              {
+                foo: bar
+                bing: bang
+                server: {
+                  host: hostname
+                }
               }
-            }
+        - name: example-configmap
+          create: false
+          readOnly: true
+          path: /app/config/example-configmap
       secretMount:
         - name: example-service-account
           readOnly: true

--- a/examples/aruba-uxi-example/values-staging.yaml
+++ b/examples/aruba-uxi-example/values-staging.yaml
@@ -39,7 +39,8 @@ aruba-uxi:
         enabled: false
         path: /
       configMap:
-        - create: true
+        - name: example-configmap01
+          create: true
           annotations: {}
           readOnly: false
           path: /app/config
@@ -52,7 +53,7 @@ aruba-uxi:
                   host: hostname
                 }
               }
-        - name: example-configmap
+        - name: example-configmap02
           create: false
           readOnly: true
           path: /app/config/example-configmap


### PR DESCRIPTION
## Description

- We can now create multiple configMaps per application
- ConfigMaps have new field `create` which defines whether the ConfigMap must be created or not
- ConfigMaps have new field `name` which affects the ConfigMap name field that the deployment links to
- Fix logic bug where false values are defaulting to true

## Types of changes

_Put an `x` in the boxes that apply._

- [x] Bugfix (`fix`): A non-breaking change which fixes an issue or bug
- [x] New Feature (`feat`): A non-breaking change which adds a new feature or new functionality
- [ ] Tests (`test`): Adding missing tests or correcting existing tests
- [ ] Refactoring (`refactor`): A code change that neither fixes a bug nor adds a feature, e.g Deleting unused or redundant code
- [ ] Documentation (`docs`): Documentation only changes
- [ ] Other (`style`, `build`, `ci`, `performance`): Formatting, linting or styling. Changes to the CI pipeline. Performance improvements. Changes that affect the build system.

## Further Information

https://uxi.atlassian.net/browse/BEP-323
