### PR TITLE
fix: liveness and readiness probes default to /health/*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - what changed
 
+## [6.0.0] - 2022-05-20
+
+### Changed
+
+- Liveness and Readiness probes now default to using `/health/live` and `/health/ready`.
+
 ## [5.0.9] - 2022-05-20
 
 ### Added

--- a/charts/aruba-uxi/Chart.yaml
+++ b/charts/aruba-uxi/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: aruba-uxi
 description: A Helm chart for Aruba UXI kubernetes resources
 type: application
-version: 5.0.9
+version: 6.0.0
 maintainers:
   - name: Aruba-UXI

--- a/charts/aruba-uxi/templates/deployment.yaml
+++ b/charts/aruba-uxi/templates/deployment.yaml
@@ -110,7 +110,7 @@ spec:
               value: readinessProbe
             - name: Content-Type
               value: application/json
-            path: {{ default "/readyz" $readinessProbe.path }}
+            path: {{ default "/health/readyz" $readinessProbe.path }}
             port: {{ $data.port }}
           initialDelaySeconds: {{ default "10" $readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ default "10" $readinessProbe.periodSeconds }}
@@ -126,7 +126,7 @@ spec:
               value: livenessProbe
             - name: Content-Type
               value: application/json
-            path: {{ default "/livez" $livenessProbe.path }}
+            path: {{ default "/health/livez" $livenessProbe.path }}
             port: {{ $data.port }}
           initialDelaySeconds: {{ default "10" $livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ default "10" $livenessProbe.periodSeconds }}

--- a/charts/aruba-uxi/values.example.yaml
+++ b/charts/aruba-uxi/values.example.yaml
@@ -88,8 +88,8 @@ aruba-uxi:
       livenessProbe:
         ## Toggles the liveness probe (optional, default: true)
         enabled: true
-        ## The API path to query for liveness testing (optional, default: /livez)
-        path: /livez
+        ## The API path to query for liveness testing (optional, default: /health/livez)
+        path: /health/livez
         ## The Number of seconds after the container starts before sending the first probe (optional, default: 10)
         initialDelaySeconds: 10
         ## How often to perform the probe (optional, default: 10)
@@ -104,8 +104,8 @@ aruba-uxi:
       readinessProbe:
         ## Toggles the readiness probe (optional, default: true)
         enabled: true
-        ## The API path to query for readiness testing (optional, default: /readyz)
-        path: /readyz
+        ## The API path to query for readiness testing (optional, default: /health/readyz)
+        path: /health/readyz
         ## The Number of seconds after the container starts before sending the first probe (optional, default: 10)
         initialDelaySeconds: 10
         ## How often to perform the probe (optional, default: 10)
@@ -206,7 +206,7 @@ aruba-uxi:
         dsn: sealed_version_of_the_base64_encoded_sentry_dsn
         ## Adds extra environment variables related to sentry (optional, default: {})
         env:
-          SENTRY_EXRA_ENV_VARIABLE_1: value
+          SENTRY_EXTRA_ENV_VARIABLE_1: value
       ## Extra labels to apply to all k8s objects. Includes any extra labels defined in the global object (optional, default: {})
       labels: {}
       ## Configures an Ingress on the application (optional, default: {})
@@ -322,7 +322,7 @@ aruba-uxi:
         dsn: sealed_version_of_the_base64_encoded_sentry_dsn
         ## Adds extra environment variables related to sentry (optional, default: {})
         env:
-          SENTRY_EXRA_ENV_VARIABLE_1: value
+          SENTRY_EXTRA_ENV_VARIABLE_1: value
       ## Extra labels to apply to all k8s objects. Includes any extra labels defined in the global object (optional, default: {})
       labels: {}
     example-cronjob-consumer: {}

--- a/examples/aruba-uxi-example/output-local.yaml
+++ b/examples/aruba-uxi-example/output-local.yaml
@@ -15,7 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -38,7 +38,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -54,7 +54,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-5.0.9
+        helm.sh/chart: aruba-uxi-6.0.0
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default

--- a/examples/aruba-uxi-example/output-production.yaml
+++ b/examples/aruba-uxi-example/output-production.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -36,7 +36,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -68,7 +68,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -93,7 +93,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -116,7 +116,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-5.0.9
+        helm.sh/chart: aruba-uxi-6.0.0
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -198,7 +198,7 @@ spec:
               value: readinessProbe
             - name: Content-Type
               value: application/json
-            path: /readyz
+            path: /health/readyz
             port: 80
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -212,7 +212,7 @@ spec:
               value: livenessProbe
             - name: Content-Type
               value: application/json
-            path: /livez
+            path: /health/livez
             port: 80
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -248,7 +248,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -265,7 +265,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-worker
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-5.0.9
+        helm.sh/chart: aruba-uxi-6.0.0
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -323,7 +323,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-consumer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -380,7 +380,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -429,7 +429,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -437,7 +437,7 @@ metadata:
     global-label: global-label
   annotations:
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      location ~ ^/(readyz|livez) {
+      location ~ ^/health/(readyz|livez|status) {
         return 404;
       }
     kubernetes.io/ingress.class: internal-gateway
@@ -459,7 +459,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -477,7 +477,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -493,7 +493,7 @@ metadata:
   name: aruba-uxi-example-image-pull-secret
   labels:
     app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     namespace: default
 spec:
@@ -505,7 +505,7 @@ spec:
       name: aruba-uxi-example-image-pull-secret
       labels:
       app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-      helm.sh/chart: aruba-uxi-5.0.9
+      helm.sh/chart: aruba-uxi-6.0.0
       app.kubernetes.io/managed-by: Helm
       namespace: default
     type: kubernetes.io/dockerconfigjson
@@ -518,7 +518,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-access
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -535,7 +535,7 @@ metadata:
   labels:
     app.kubernetes.io/name: database-url
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -551,7 +551,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service-account
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -36,7 +36,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -68,7 +68,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -93,7 +93,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -116,7 +116,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-5.0.9
+        helm.sh/chart: aruba-uxi-6.0.0
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -215,7 +215,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -232,7 +232,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-worker
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-5.0.9
+        helm.sh/chart: aruba-uxi-6.0.0
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -282,7 +282,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-consumer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -337,7 +337,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -386,7 +386,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -394,7 +394,7 @@ metadata:
     global-label: global-label
   annotations:
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      location ~ ^/(readyz|livez) {
+      location ~ ^/health/(readyz|livez|status) {
         return 404;
       }
 spec:
@@ -419,7 +419,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -435,7 +435,7 @@ metadata:
   name: aruba-uxi-example-image-pull-secret
   labels:
     app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     namespace: default
 spec:
@@ -447,7 +447,7 @@ spec:
       name: aruba-uxi-example-image-pull-secret
       labels:
       app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-      helm.sh/chart: aruba-uxi-5.0.9
+      helm.sh/chart: aruba-uxi-6.0.0
       app.kubernetes.io/managed-by: Helm
       namespace: default
     type: kubernetes.io/dockerconfigjson
@@ -460,7 +460,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-access
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -477,7 +477,7 @@ metadata:
   labels:
     app.kubernetes.io/name: database-url
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -493,7 +493,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service-account
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-5.0.9
+    helm.sh/chart: aruba-uxi-6.0.0
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default

--- a/examples/aruba-uxi-example/values-production.yaml
+++ b/examples/aruba-uxi-example/values-production.yaml
@@ -85,7 +85,7 @@ aruba-uxi:
         className: internal-gateway
         annotations:
           nginx.ingress.kubernetes.io/configuration-snippet: |
-            location ~ ^/(readyz|livez) {
+            location ~ ^/health/(readyz|livez|status) {
               return 404;
             }
         hosts:

--- a/examples/aruba-uxi-example/values-staging.yaml
+++ b/examples/aruba-uxi-example/values-staging.yaml
@@ -75,7 +75,7 @@ aruba-uxi:
         className: internal-gateway
         annotations:
           nginx.ingress.kubernetes.io/configuration-snippet: |
-            location ~ ^/(readyz|livez) {
+            location ~ ^/health/(readyz|livez|status) {
               return 404;
             }
         hosts:


### PR DESCRIPTION
## Description

Major version bump to change the default health endpoints to `/health/*`

## Types of changes

_Put an `x` in the boxes that apply._

- [ ] Bugfix (`fix`): A non-breaking change which fixes an issue or bug
- [x] New Feature (`feat`): A non-breaking change which adds a new feature or new functionality
- [ ] Tests (`test`): Adding missing tests or correcting existing tests
- [ ] Refactoring (`refactor`): A code change that neither fixes a bug nor adds a feature, e.g Deleting unused or redundant code
- [ ] Documentation (`docs`): Documentation only changes
- [ ] Other (`style`, `build`, `ci`, `performance`): Formatting, linting or styling. Changes to the CI pipeline. Performance improvements. Changes that affect the build system.
