### PR TITLE
Added a dogstatsd sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - what changed
 
+
+## [6.0.1] - 2022-05-30
+
+### Changed
+
+- added `datadog.useSocat` which switches from using the node HostIP to using a locally deployed socat sidecar. The sidecar will listen on the UDP port and forward statsd traffic to the dogstatsd unix socket which is mounted into the sidecar container.
+
 ## [6.0.0] - 2022-05-20
 
 ### Changed

--- a/charts/aruba-uxi/Chart.yaml
+++ b/charts/aruba-uxi/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: aruba-uxi
 description: A Helm chart for Aruba UXI kubernetes resources
 type: application
-version: 6.0.0
+version: 6.0.1
 maintainers:
   - name: Aruba-UXI

--- a/charts/aruba-uxi/templates/deployment.yaml
+++ b/charts/aruba-uxi/templates/deployment.yaml
@@ -170,14 +170,14 @@ spec:
           - "-s"
           - "-u"
           - "UDP-RECV:8125"
-          - "UNIX-SENDTO:/var/run/dogstatsd/dsd.socket"
+          - "UNIX-SENDTO:/var/run/datadog/dsd.socket"
         ports:
           - containerPort: 8125
             name: dogstatsd
             protocol: UDP
         volumeMounts:
           - name: dsdsocket
-            mountPath: /var/run/dogstatsd
+            mountPath: /var/run/datadog
       {{- end }}
       {{- with $data.nodeSelector }}
       nodeSelector:
@@ -196,7 +196,7 @@ spec:
       {{- if $datadog.useSocat }}
       - name: dsdsocket
         hostPath:
-          path: /var/run/dogstatsd
+          path: /var/run/datadog
       {{- end }}
       {{- if $data.configMap }}
       {{- range $configMapData := $data.configMap }}

--- a/charts/aruba-uxi/templates/deployment.yaml
+++ b/charts/aruba-uxi/templates/deployment.yaml
@@ -71,10 +71,15 @@ spec:
         - name: DD_TRACE_ENABLED
           value: {{ default "false" $datadog.traceEnabled | quote }}
         {{- if $datadog.enabled }}
+        {{- if $datadog.useSocat }}
+        - name: DD_AGENT_HOST
+          value: "localhost"
+        {{- else}}
         - name: DD_AGENT_HOST
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        {{- end }}
         - name: DD_ENTITY_ID
           valueFrom:
             fieldRef:
@@ -158,6 +163,22 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+      {{- if $datadog.useSocat }}
+      - name: datadog-socat
+        image: alpine/socat
+        args:
+          - "-s"
+          - "-u"
+          - "UDP-RECV:8125"
+          - "UNIX-SENDTO:/var/run/dogstatsd/dsd.socket"
+        ports:
+          - containerPort: 8125
+            name: dogstatsd
+            protocol: UDP
+        volumeMounts:
+          - name: dsdsocket
+            mountPath: /var/run/dogstatsd
+      {{- end }}
       {{- with $data.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -172,6 +193,11 @@ spec:
       {{- end }}
       {{- if or $data.configMap $data.secretMount }}
       volumes:
+      {{- if $datadog.useSocat }}
+      - name: dsdsocket
+        hostPath:
+          path: /var/run/dogstatsd
+      {{- end }}
       {{- if $data.configMap }}
       {{- range $configMapData := $data.configMap }}
       - name: {{ $configMapData.name }}-volume

--- a/charts/aruba-uxi/templates/deployment.yaml
+++ b/charts/aruba-uxi/templates/deployment.yaml
@@ -71,15 +71,10 @@ spec:
         - name: DD_TRACE_ENABLED
           value: {{ default "false" $datadog.traceEnabled | quote }}
         {{- if $datadog.enabled }}
-        {{- if $datadog.useSocat }}
-        - name: DD_AGENT_HOST
-          value: localhost
-        {{- else}}
         - name: DD_AGENT_HOST
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        {{- end }}
         - name: DD_ENTITY_ID
           valueFrom:
             fieldRef:

--- a/charts/aruba-uxi/templates/deployment.yaml
+++ b/charts/aruba-uxi/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
         {{- if $datadog.enabled }}
         {{- if $datadog.useSocat }}
         - name: DD_AGENT_HOST
-          value: "localhost"
+          value: localhost
         {{- else}}
         - name: DD_AGENT_HOST
           valueFrom:

--- a/examples/aruba-uxi-example/output-local.yaml
+++ b/examples/aruba-uxi-example/output-local.yaml
@@ -15,7 +15,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -38,7 +38,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -54,7 +54,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-6.0.0
+        helm.sh/chart: aruba-uxi-6.0.1
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default

--- a/examples/aruba-uxi-example/output-production.yaml
+++ b/examples/aruba-uxi-example/output-production.yaml
@@ -233,18 +233,18 @@ spec:
           - "-s"
           - "-u"
           - "UDP-RECV:8125"
-          - "UNIX-SENDTO:/var/run/dogstatsd/dsd.socket"
+          - "UNIX-SENDTO:/var/run/datadog/dsd.socket"
         ports:
           - containerPort: 8125
             name: dogstatsd
             protocol: UDP
         volumeMounts:
           - name: dsdsocket
-            mountPath: /var/run/dogstatsd
+            mountPath: /var/run/datadog
       volumes:
       - name: dsdsocket
         hostPath:
-          path: /var/run/dogstatsd
+          path: /var/run/datadog
       - name: example-configmap01-volume
         configMap:
           name: example-configmap01

--- a/examples/aruba-uxi-example/output-production.yaml
+++ b/examples/aruba-uxi-example/output-production.yaml
@@ -146,7 +146,7 @@ spec:
         - name: DD_TRACE_ENABLED
           value: "true"
         - name: DD_AGENT_HOST
-          value: "localhost"
+          value: localhost
         - name: DD_ENTITY_ID
           valueFrom:
             fieldRef:

--- a/examples/aruba-uxi-example/output-production.yaml
+++ b/examples/aruba-uxi-example/output-production.yaml
@@ -146,7 +146,9 @@ spec:
         - name: DD_TRACE_ENABLED
           value: "true"
         - name: DD_AGENT_HOST
-          value: localhost
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: DD_ENTITY_ID
           valueFrom:
             fieldRef:

--- a/examples/aruba-uxi-example/output-production.yaml
+++ b/examples/aruba-uxi-example/output-production.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -36,7 +36,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -68,7 +68,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -93,7 +93,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -116,7 +116,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-6.0.0
+        helm.sh/chart: aruba-uxi-6.0.1
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -146,9 +146,7 @@ spec:
         - name: DD_TRACE_ENABLED
           value: "true"
         - name: DD_AGENT_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
+          value: "localhost"
         - name: DD_ENTITY_ID
           valueFrom:
             fieldRef:
@@ -229,7 +227,24 @@ spec:
         - name: example-service-account
           mountPath: /tmp
           readOnly: true
+      - name: datadog-socat
+        image: alpine/socat
+        args:
+          - "-s"
+          - "-u"
+          - "UDP-RECV:8125"
+          - "UNIX-SENDTO:/var/run/dogstatsd/dsd.socket"
+        ports:
+          - containerPort: 8125
+            name: dogstatsd
+            protocol: UDP
+        volumeMounts:
+          - name: dsdsocket
+            mountPath: /var/run/dogstatsd
       volumes:
+      - name: dsdsocket
+        hostPath:
+          path: /var/run/dogstatsd
       - name: example-configmap01-volume
         configMap:
           name: example-configmap01
@@ -248,7 +263,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -265,7 +280,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-worker
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-6.0.0
+        helm.sh/chart: aruba-uxi-6.0.1
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -323,7 +338,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-consumer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -380,7 +395,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -429,7 +444,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -459,7 +474,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -477,7 +492,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -493,7 +508,7 @@ metadata:
   name: aruba-uxi-example-image-pull-secret
   labels:
     app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     namespace: default
 spec:
@@ -505,7 +520,7 @@ spec:
       name: aruba-uxi-example-image-pull-secret
       labels:
       app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-      helm.sh/chart: aruba-uxi-6.0.0
+      helm.sh/chart: aruba-uxi-6.0.1
       app.kubernetes.io/managed-by: Helm
       namespace: default
     type: kubernetes.io/dockerconfigjson
@@ -518,7 +533,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-access
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -535,7 +550,7 @@ metadata:
   labels:
     app.kubernetes.io/name: database-url
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -551,7 +566,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service-account
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default

--- a/examples/aruba-uxi-example/output-staging.yaml
+++ b/examples/aruba-uxi-example/output-staging.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -36,7 +36,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -68,7 +68,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -93,7 +93,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -116,7 +116,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-service
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-6.0.0
+        helm.sh/chart: aruba-uxi-6.0.1
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -215,7 +215,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -232,7 +232,7 @@ spec:
       labels:
         app.kubernetes.io/name: example-worker
         app.kubernetes.io/instance: aruba-uxi-example
-        helm.sh/chart: aruba-uxi-6.0.0
+        helm.sh/chart: aruba-uxi-6.0.1
         app.kubernetes.io/managed-by: Helm
         repository: aruba-uxi-example
         namespace: default
@@ -282,7 +282,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-consumer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -337,7 +337,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-cronjob-producer
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -386,7 +386,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -419,7 +419,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-worker
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -435,7 +435,7 @@ metadata:
   name: aruba-uxi-example-image-pull-secret
   labels:
     app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     namespace: default
 spec:
@@ -447,7 +447,7 @@ spec:
       name: aruba-uxi-example-image-pull-secret
       labels:
       app.kubernetes.io/name: aruba-uxi-example-image-pull-secret
-      helm.sh/chart: aruba-uxi-6.0.0
+      helm.sh/chart: aruba-uxi-6.0.1
       app.kubernetes.io/managed-by: Helm
       namespace: default
     type: kubernetes.io/dockerconfigjson
@@ -460,7 +460,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-access
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -477,7 +477,7 @@ metadata:
   labels:
     app.kubernetes.io/name: database-url
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default
@@ -493,7 +493,7 @@ metadata:
   labels:
     app.kubernetes.io/name: example-service-account
     app.kubernetes.io/instance: aruba-uxi-example
-    helm.sh/chart: aruba-uxi-6.0.0
+    helm.sh/chart: aruba-uxi-6.0.1
     app.kubernetes.io/managed-by: Helm
     repository: aruba-uxi-example
     namespace: default

--- a/examples/aruba-uxi-example/values-production.yaml
+++ b/examples/aruba-uxi-example/values-production.yaml
@@ -69,6 +69,7 @@ aruba-uxi:
           - AWS_ACCESS_ID
       datadog:
         enabled: true
+        useSocat: true
         traceEnabled: true
         serviceName: another-service-name
         env:


### PR DESCRIPTION
## Description

Gunicorn does not support unix sockets for dogstatsd and we could not get our nodes to open up the UDP port 8125. 
This mounts a dogstatsd unix socket into a sidecar container which runs socat and forwards any UDP port 8125 traffic within the pod to the unix socket. 

## Types of changes

_Put an `x` in the boxes that apply._

- [ ] Bugfix (`fix`): A non-breaking change which fixes an issue or bug
- [x] New Feature (`feat`): A non-breaking change which adds a new feature or new functionality
- [ ] Tests (`test`): Adding missing tests or correcting existing tests
- [ ] Refactoring (`refactor`): A code change that neither fixes a bug nor adds a feature, e.g Deleting unused or redundant code
- [ ] Documentation (`docs`): Documentation only changes
- [ ] Other (`style`, `build`, `ci`, `performance`): Formatting, linting or styling. Changes to the CI pipeline. Performance improvements. Changes that affect the build system.

## Further Information

JIRA Ticket: <https://uxi.atlassian.net/browse/BEP-XXX>

Any relevant logs, screenshots, testing output, etc...
